### PR TITLE
Simplify pickle __getstate__

### DIFF
--- a/uncertainties/__init__.py
+++ b/uncertainties/__init__.py
@@ -1060,6 +1060,8 @@ class AffineScalarFunc(object):
             # Include all values of all slots in the class hierarchy
             obj_slot_values.update((k, getattr(self, k))
                 for k in getattr(cls, '__slots__', ()))
+        # support subclasses that do not use __slots__
+        obj_slot_values.update(getattr(self, '__dict__', {}))
         return obj_slot_values
 
     def __setstate__(self, data_dict):


### PR DESCRIPTION
Your `uncertainties.AffineScalarFunc.__getstate__` method makes it harder for subclasses to add extra `__slots__` attributes, requiring them to provide their own `__getstate__` method.

The `uncertainties.Variable` class has to do does just that; create it's own `__getstate__` that looks at the `self.__slots__` attribute then adds the `__getstate__` result of it's parent class to get a complete pickle state.

This pull request replaces the `AffineScalarFunc.__getstate__` method with one that scans the whole inheritance tree (in MRO order) for `__slot__` attributes _on the classes_, then builds the pickle state from those.

This makes subclassing either `AffineScalarFunc` or `Variable` easier; all you need to do is add your own `__slots__` attribute with additional attributes to be pickled.

See this [Stack Overflow question](http://stackoverflow.com/questions/15117372/pickle-attributeerror-module-object-has-no-attribute) for further context for this patch.
