### PR TITLE
support both setuptools & distutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ doc/_build
 dist
 MANIFEST
 uncertainties.egg-info/
+
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ else:
 # sys.path.insert(0, package_dir)
 # uncertainties = __import__(package_dir)
 
-
 # Common options for distutils/setuptools's setup():
 setup_options = dict(
     name='uncertainties',
@@ -297,35 +296,35 @@ _of_uncertainty
               'derivatives', 'partial derivatives', 'differentiation'],
     
     classifiers=[
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Education',
-    'Intended Audience :: Other Audience',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2.3',
-    'Programming Language :: Python :: 2.4',
-    'Programming Language :: Python :: 2.5',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    # Python 3.1 failed because of a problem with NumPy 1.6.1 (whereas
-    # everything was fine with Python 3.2 and Python 2.7).
-    'Programming Language :: Python :: 3.1',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: Implementation :: Jython',
-    'Programming Language :: Python :: Implementation :: PyPy',
-    'Topic :: Education',
-    'Topic :: Scientific/Engineering',
-    'Topic :: Scientific/Engineering :: Mathematics',
-    'Topic :: Scientific/Engineering :: Physics',
-    'Topic :: Software Development',
-    'Topic :: Software Development :: Libraries',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-    'Topic :: Utilities'
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Intended Audience :: Other Audience',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.3',
+        'Programming Language :: Python :: 2.4',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        # Python 3.1 failed because of a problem with NumPy 1.6.1 (whereas
+        # everything was fine with Python 3.2 and Python 2.7).
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: Implementation :: Jython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Education',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Scientific/Engineering :: Physics',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Utilities'
     ],
 
     # Where to find the source code:
@@ -334,8 +333,8 @@ _of_uncertainty
     # Files are defined in MANIFEST (which is automatically created by
     # python setup.py sdist):
     packages=['uncertainties', 'uncertainties.unumpy',
-              'uncertainties.lib1to2', 'uncertainties.lib1to2.fixes']
-    )
+              'uncertainties.lib1to2', 'uncertainties.lib1to2.fixes'],
+)
 
 # The best available setup() is used (some users do not have
 # setuptools):
@@ -343,29 +342,29 @@ try:
     from setuptools import setup
 
     # Some setuptools-specific options can be added:
-    
-    tests_require = ['nose']
-    
-    setup_options.update(dict(
-
-        # !!!! Used for what? does not allow python3 setup.py test to succeed:
-        use_2to3=True,
-        
-        # Enables nosetests testing via setup.py's test command:
-        test_suite='nose.collector',
+    tests_require = ['nose', 'numpy']
+    optional_require = ['numpy']
+    docs_require = ['sphinx']
+    all_extra = set(tests_require + optional_require + docs_require)
+    kw = {
+        # allows python setup.py nosetests to do the right thing
+        'use_2to3': True,
         # Automatically fetches nose if not yet installed:
-        tests_require=tests_require,
-        
-        # Optional setup.py commands: # !!! Used how?
-        extras_require={
+        'tests_require': tests_require,
+        # Optional dependencies install using:
+        # `easy_install uncertainties[optional]`
+        'extras_require': {
+            'optional': optional_require,
             'tests': tests_require,
-            'docs': ["sphinx"]
-            }
-        ))
+            'docs': docs_require,
+            'all': all_extra
+        }
+    }
+    setup_options.update(kw)
 
 except ImportError:
     from distutils.core import setup
 
+# End of setup definition
+
 setup(**setup_options)
-
-


### PR DESCRIPTION
1. should work with both distutils and setuptools
2. updated optional deps list
3. setup.py nosetests should work for both 3.3 and 2.7 b
4. more pep8 for setup.py
