### PR TITLE
Use cholesky decomposition in correlated_values and correlated_values_norm

### DIFF
--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -195,7 +195,7 @@ else:
 
             a = A[i, i]
             l = A[i+1:, i]
-            if a < -EPS or (a <= 0 and abs(l).max() >= EPS):
+            if a < -EPS or (a <= 0 and len(l) > 0 and abs(l).max() >= EPS):
                 raise numpy.linalg.LinAlgError('matrix must be positive '
                     'semidefinite (failed on %s-th diagonal entry)' % i)
 

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -180,7 +180,7 @@ else:
 
         A -- a square symmetric positive semi-definite matrix
         """
-        EPS = 1.49e-8 # square root of float64-accuracy
+        TOL = 1.49e-8 # square root of float64-accuracy
 
         n, n_ = numpy.shape(A)
         if n != n_:

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -160,10 +160,10 @@ else:
         # perform a cholesky decomposition so we 'manually' do a LDL
         # decomposition
         try:
-            L = numpy.cholesky(covariance_mat)
-        except numpy.LinAlgError:
+            L = numpy.linalg.cholesky(covariance_mat)
+        except numpy.linalg.LinAlgError:
             L0, D = ldl(covariance_mat)
-            L = numpy.dot(L0, sqrt(D))
+            L = L0 * numpy.sqrt(D)
 
         if tags is None:
             tags = (None, ) * len(nom_values)
@@ -186,7 +186,7 @@ else:
         if n != n_:
             raise numpy.linalg.LinAlgError('matrix must be square')
 
-        A = numpy.array(A, copy=True)
+        A = numpy.array(A, copy=True, dtype=numpy.float64)
         L = numpy.zeros_like(A) # we will only write in the lower half of L
         D = numpy.zeros(n)
 

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -240,12 +240,12 @@ else:
         tags -- like for correlated_values().
         '''
 
+        (nominal_values, std_devs) = numpy.transpose(values_with_std_dev)
+
         # If no tags were given, we prepare tags for the newly created
         # variables:
         if tags is None:
-            tags = (None,) * len(values_with_std_dev)
-
-        (nominal_values, std_devs) = numpy.transpose(values_with_std_dev)
+            tags = (None,) * len(nominal_values)
 
         # For values with zero uncertainty we ignore the corresponding entries
         # in the correlation matrix

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -241,7 +241,7 @@ else:
         tags -- like for correlated_values().
         '''
 
-        (nominal_values, std_devs) = numpy.transpose(values_with_std_dev)
+        nominal_values, std_devs = numpy.transpose(values_with_std_dev)
 
         # If no tags were given, we prepare tags for the newly created
         # variables:

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -201,13 +201,14 @@ else:
 
             a = A[i, i]
             l = A[i+1:, i]
-            if a < -TOL or (a <= 0 and len(l) > 0 and abs(l).max() >= TOL):
-                raise numpy.linalg.LinAlgError('matrix must be positive '
-                    'semidefinite (failed on %s-th diagonal entry)' % i)
 
             if a <= 0:
+                if a < -TOL or (i < n - 1 and any(abs(l) >= TOL)):
+                    raise numpy.linalg.LinAlgError('matrix must be positive '
+                        'semidefinite (failed on %s-th diagonal entry)' % i)
+                # If we get here, then the whole first column of L[i:, i:] is
+                # (nearly) zero
                 D[i] = 0
-                continue
             else:
                 D[i] = a
                 L[i+1:, i] = l / a


### PR DESCRIPTION
This uses a Cholesky decomposition instead of diagonalization in `correlated_values` and `correlated_values_norm`. The idea is the same as presented in #99.

However, dealing with degenerate covariance matrices proved to be a bit tricky, since numpy refuses to do a Cholesky decomposition of a matrix that is only positive *semi*-definite. Therefore I added a function that performs a LDL decomposition in those cases (this would also be available in scipy).

Local tests (and theory) suggest that this should be more precise and faster than the old implementation.

Both `correlated_values` and `correlated_values_norm` now raise an error if the covariance/correlation matrix fails to be (nearly) positive semi-definite. 