### PR TITLE
Drop official support for Python versions before 3.8

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -107,6 +107,15 @@ gives access to many of the documentation strings included in the code.
 Installation and download
 =========================
 
+Supported Python versions
+-------------------------
+
+The :mod:`uncertainties` package supports all versions of Python supported by
+the upstream Python_ project.  As of early 2024, that means versions 3.8
+through 3.12.  It may be possible to support earlier versions if there is user
+demand.  Versions of the :mod:`uncertainties` package up through 3.1.7
+supported Python 2.7 through Python 3.12.
+
 Important note
 --------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -110,11 +110,13 @@ Installation and download
 Supported Python versions
 -------------------------
 
-The :mod:`uncertainties` package supports all versions of Python supported by
-the upstream Python_ project.  As of early 2024, that means versions 3.8
-through 3.12.  It may be possible to support earlier versions if there is user
-demand.  Versions of the :mod:`uncertainties` package up through 3.1.7
-supported Python 2.7 through Python 3.12.
+The :mod:`uncertainties` package supports Python versions 3.8 and higher.
+Earlier versions of Python are not tested. :mod:`uncertainties` may still
+be compatible with them. Patches to restore compatibility with earlier versions
+of Python may be considered if they do not compromise performance or
+maintainability for the supported versions of Python.  Versions of the
+:mod:`uncertainties` package up through 3.1.7 supported Python 2.7 through
+Python 3.12.
 
 Important note
 --------------

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# !! This program must run with all version of Python since 2.3 included.
-
 import os
 import sys
-
-# setuptools has python_requires, but distutils doesn't, so we test the
-# Python version manually:
-min_version = (2, 7)
-error_msg = ("Sorry, this package is for Python %d.%d and higher only." %
-             min_version)
-try:
-    if sys.version_info < min_version:
-        sys.exit(error_msg)
-except AttributeError:  # sys.version_info was introduced in Python 2.0
-    sys.exit(error_msg)
 
 # Common options for distutils/setuptools's setup():
 setup_options = dict(
@@ -280,19 +267,12 @@ Main changes:
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        # Python 3.1 failed because of a problem with NumPy 1.6.1 (whereas
-        # everything was fine with Python 3.2 and Python 2.7).
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: Jython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Education',


### PR DESCRIPTION
This change does not modify any code, so the codebase is still actually compatible with Python 2.7 through 3.7, but it gives the project the freedom to make incompatible changes with versions in that range in subsequent commits.

A note in the documentation states that compatibility with earlier versions could be considered if there is user demand.