### PR TITLE
Implement hash for AffineScalarFunc

### DIFF
--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -1935,3 +1935,21 @@ else:
         assert uarrays_close(
             numpy.array(cov_mat),
             numpy.array(uncert_core.covariance_matrix([x2, y2, z2])))
+
+    def test_hash():
+        '''
+        Tests the invariance that if x==y, then hash(x)==hash(y)
+        '''
+
+        x = ufloat(1.23, 2.34)
+        y = ufloat(1.23, 2.34)
+        # nominal values and std_dev terms are equal, but...
+        assert x.n==y.n and x.s==y.s
+        # ...x and y are independent variables, therefore not equal as uncertain numbers
+        assert x != y
+        assert hash(x) != hash(y)
+
+        # the equation (2x+x)/3 is equal to the variable x, so...
+        assert ((2*x+x)/3)==x
+        # ...hash of the equation and the variable should be equal
+        assert hash((2*x+x)/3)==hash(x)

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1826,6 +1826,15 @@ class AffineScalarFunc(object):
     # Abbreviation (for formulas, etc.):
     s = std_dev
 
+    def __hash__(self):
+        if not self._linear_part.expanded():
+           self._linear_part.expand()
+        combo = tuple(iter(self._linear_part.linear_combo.items()))
+        if len(combo) > 1 or combo[0][1] != 1.0:
+           return hash(combo)
+        # The unique value that comes from a unique variable (which it also hashes to)
+        return id(combo[0][0])
+
     def __repr__(self):
         # Not putting spaces around "+/-" helps with arrays of
         # Variable, as each value with an uncertainty is a
@@ -2792,7 +2801,19 @@ class Variable(AffineScalarFunc):
         # variables, so they never compare equal; therefore, their
         # id() are allowed to differ
         # (http://docs.python.org/reference/datamodel.html#object.__hash__):
-        return id(self)
+
+        # Also, since the _linear_part of a variable is based on self, we can use
+        # that as a hash (uniqueness of self), which allows us to also
+        # preserve the invariance that x == y implies hash(x) == hash(y)
+        if hasattr(self, '_linear_part'):
+            if (
+                hasattr(self._linear_part, 'linear_combo')
+                and self in iter(self._linear_part.linear_combo.keys())
+            ):
+                return id(tuple(iter(self._linear_part.linear_combo.keys()))[0])
+            return hash(self._linear_part)
+        else:
+            return id(self)
 
     def __copy__(self):
         """

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1756,6 +1756,17 @@ class AffineScalarFunc(object):
 
     ########################################
 
+    def __hash__(self):
+        """
+        Calculates the hash for any AffineScalarFunc object.
+        
+        Returns:
+            int: The hash of this object
+        """
+
+        ids = [id(d) for d in self.derivatives.keys()]
+        return hash((self._nominal_value, self._linear_part, tuple(ids)))
+
     # Uncertainties handling:
 
     def error_components(self):

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1502,6 +1502,16 @@ class LinearCombination(object):
         """
         return bool(self.linear_combo)
 
+    def copy(self):
+        """Shallow copy of the LinearCombination object.
+
+        Returns:
+            LinearCombination: Copy of the object.
+        """
+        cpy = LinearCombination.__new__(LinearCombination)
+        cpy.linear_combo = self.linear_combo.copy()
+        return cpy
+
     def expanded(self):
         """
         Return True if and only if the linear combination is expanded.
@@ -1759,13 +1769,16 @@ class AffineScalarFunc(object):
     def __hash__(self):
         """
         Calculates the hash for any AffineScalarFunc object.
+        The hash is calculated from the nominal_value, and the derivatives.
         
         Returns:
             int: The hash of this object
         """
 
-        ids = [id(d) for d in self.derivatives.keys()]
-        return hash((self._nominal_value, self._linear_part, tuple(ids)))
+        # derivatives which are zero must be filtered out, because the variable is insensitive to errors in those correlations.
+        # the derivatives must be sorted, because the hash depends on the order, but the equality of variables does not.
+        derivatives = sorted([(id(key), value) for key, value in self.derivatives.items() if value != 0])
+        return hash((self._nominal_value, tuple(derivatives)))
 
     # Uncertainties handling:
 
@@ -1825,15 +1838,6 @@ class AffineScalarFunc(object):
 
     # Abbreviation (for formulas, etc.):
     s = std_dev
-
-    def __hash__(self):
-        if not self._linear_part.expanded():
-           self._linear_part.expand()
-        combo = tuple(iter(self._linear_part.linear_combo.items()))
-        if len(combo) > 1 or combo[0][1] != 1.0:
-           return hash(combo)
-        # The unique value that comes from a unique variable (which it also hashes to)
-        return id(combo[0][0])
 
     def __repr__(self):
         # Not putting spaces around "+/-" helps with arrays of
@@ -2442,6 +2446,7 @@ class AffineScalarFunc(object):
         """
         Hook for the pickle module.
         """
+
         for (name, value) in data_dict.items():
             # Contrary to the default __setstate__(), this does not
             # necessarily save to the instance dictionary (because the
@@ -2749,7 +2754,7 @@ class Variable(AffineScalarFunc):
         # differentiable functions: for instance, Variable(3, 0.1)/2
         # has a nominal value of 3/2 = 1, but a "shifted" value
         # of 3.1/2 = 1.55.
-        value = float(value)
+        self._nominal_value = float(value)
 
         # If the variable changes by dx, then the value of the affine
         # function that gives its value changes by 1*dx:
@@ -2759,7 +2764,7 @@ class Variable(AffineScalarFunc):
         # takes much more memory.  Thus, this implementation chooses
         # more cycles and a smaller memory footprint instead of no
         # cycles and a larger memory footprint.
-        super(Variable, self).__init__(value, LinearCombination({self: 1.}))
+        super(Variable, self).__init__(self._nominal_value, LinearCombination({self: 1.}))
 
         self.std_dev = std_dev  # Assignment through a Python property
 
@@ -2786,6 +2791,27 @@ class Variable(AffineScalarFunc):
 
         self._std_dev = float(std_dev)
 
+    def __hash__(self):
+        """
+        Calculates the hash for any `Variable` object.
+        The implementation is the same as for `AffineScalarFunc`.
+        But this method sets the `_linear_part` manually.
+        It is set to a single entry with a self reference as key and 1.0 as value.
+        
+        Returns:
+            int: The hash of this object
+        """
+
+        # The manual implementation of the _linear_part is necessary, because pickle would not work otherwise.
+        # That is because of the self reference inside the _linear_part.
+        return hash((self._nominal_value, ((id(self), 1.),)))
+
+    # Support for legacy method:
+    def set_std_dev(self, value):  # Obsolete
+        deprecation('instead of set_std_dev(), please use'
+                    ' .std_dev = ...')
+        self.std_dev = value
+
     # The following method is overridden so that we can represent the tag:
     def __repr__(self):
 
@@ -2795,25 +2821,6 @@ class Variable(AffineScalarFunc):
             return num_repr
         else:
             return "< %s = %s >" % (self.tag, num_repr)
-
-    def __hash__(self):
-        # All Variable objects are by definition independent
-        # variables, so they never compare equal; therefore, their
-        # id() are allowed to differ
-        # (http://docs.python.org/reference/datamodel.html#object.__hash__):
-
-        # Also, since the _linear_part of a variable is based on self, we can use
-        # that as a hash (uniqueness of self), which allows us to also
-        # preserve the invariance that x == y implies hash(x) == hash(y)
-        if hasattr(self, '_linear_part'):
-            if (
-                hasattr(self._linear_part, 'linear_combo')
-                and self in iter(self._linear_part.linear_combo.keys())
-            ):
-                return id(tuple(iter(self._linear_part.linear_combo.keys()))[0])
-            return hash(self._linear_part)
-        else:
-            return id(self)
 
     def __copy__(self):
         """
@@ -2848,6 +2855,34 @@ class Variable(AffineScalarFunc):
         # Reference: http://www.doughellmann.com/PyMOTW/copy/index.html
 
         return self.__copy__()
+
+    def __getstate__(self):
+        """
+        Hook for the pickle module.
+
+        Same as for the AffineScalarFunction but remove the linear part,
+        since it only contains a self reference.
+        This would lead to problems when unpickling the linear part.
+        """
+                
+        LINEAR_PART_NAME = "_linear_part"
+        state = super().__getstate__()
+
+        if LINEAR_PART_NAME in state:
+            del state[LINEAR_PART_NAME]
+
+        return state
+
+    def __setstate__(self, state):
+        """
+        Hook for the pickle module.
+
+        Same as for AffineScalarFunction, but manually set the linear part.
+        This one is removed when pickling Variable objects.
+        """
+
+        super().__setstate__(state)
+        self._linear_part = LinearCombination({self: 1.})
 
 
 ###############################################################################


### PR DESCRIPTION
It is more than a week now, that I closed #189 and asked to continue discussion inside the issues of my Fork.
Nobody opened an issue. Because of that, I think that there are no further discrepancies between @wshanks, @MichaelTiemannOSC and me.
So, I want to try again and merge this changes :)

In the current master branch, there is no `__hash__` function for `AffineScalarFunc` but for `Variable`:

```py
def __hash__(self):
        # All Variable objects are by definition independent
        # variables, so they never compare equal; therefore, their
        # id() are allowed to differ
        # (http://docs.python.org/reference/datamodel.html#object.__hash__):
        return id(self)
```

## Basics about hashes 

If we just need a hash for `Variable`, this would be sufficient, but it is possible to make `AffineScalarFunc` hashable and I think we should provide a `__hash__` function for `AffineScalarFunc` objects as well.

First, let us take a deeper look into python glossary about the term [`hashable`](https://docs.python.org/3/glossary.html#term-hashable).
It describes to requirements:

> An object is hashable if it has a hash value which never changes during its lifetime

From this requirement, it follows that the hash must be independent from the state of the object, because otherwise the hash could change during lifetime. That means, that we can only use immutable properties of the object, to calculate the hash.

> Hashable objects which compare equal must have the same hash value.

If we use the same properties, that are used to determine equality, to calculate the hash, this requirement is fulfilled.

## Hashes in the uncertainties package

Let us now check how `AffinceScalarFunc` behaves in the uncertainties package.
Equality of two `AffineScalarFunc` objects is relatively complicate and I do not really want to step into details here.
Currently there is another issue discussing that in more detail.
However, if we use the `_linear_part` property and the `_nominal_value` property, we are able to calculate a hash, that compares equal, if two `AffineScalarFunc` objects compare equal.

But there is still a problem, the hash equality must also be guaranteed, for comparisons, where a `AffineScalarFunc` object and a `Variable` object are equal.
Because of that, we cannot keep the original implementation of `__hash__` inside the `Variable` object.
Instead, we need to use the same calculation for `Variable::__hash_` as we use for `AffineScalarFunc;:__hash__`.
Normally, removing the `__hash__` function from `Variable` would do the trick, since `AffineScalarFunc` is the base class of `Variable`.
However, there one problem.

But before I explain this problem, let us check if the implementation of `AffineScalarFunc::__hash__` fulfills the first requirement of `hashable`.
We note, that the `AffienScalarFunc` objects are mutable, which might be problem.
But fortunately, the expanded version of `_linear_part`, as well as the `_nominal_value` are immutable.
Because of that, also the hash is immutable and cannot change during the entire lifetime.

Now let us step into the reason, why we need to use a slightly different implementation of `__hash__` for `Variable`.
The `Variable` object has a self reference inside the `_linear_part`.
This is a problem, when unpickling a `Variable` object. The reason for that is, that the pickle will first generate the `LinearCombination` object, before it generate the `Variable` object. While doing so, it tries to calculate the hash from the self reference. But the `Variable` object does not exist and the calculation will fail.
For the same reason, the `__getstate__` and `__setstate__` function must be implemented.

In the end, I want to thank everybody, who contributed to this PR.