### PR TITLE
Update unumpy test to be compatible with numpy 2

### DIFF
--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -251,9 +251,11 @@ def test_broadcast_funcs():
     # Some functions do not bear the same name in the math module and
     # in NumPy (acos instead of arccos, etc.):
     assert unumpy.arccos(arr)[1] == uncertainties.umath.acos(arr[1])
-    # The acos() function should not exist in unumpy because it does
-    # not exist in numpy:
-    assert not hasattr(numpy, 'acos')
+
+    # The acos() function should not exist in unumpy because the function
+    # should have been renamed to arccos(). Starting with numpy 2 numpy.acos()
+    # is an alias to numpy.arccos(). If similar aliases are added to unumpy,
+    # the following tests can be removed.
     assert not hasattr(unumpy, 'acos')
 
     # Test of the __all__ variable:


### PR DESCRIPTION
`uncertainties` defines error-propagating versions of several of the functions in the `math` module. Then in the `unumpy` code, it iterates over this same set and defines array-compatible versions of those functions using `numpy.vectorize`. Because before numpy 2 numpy used different names for the inverse trigonometric functions (`arccos` vs `acos`), the code needed to change the name for the numpy version. One place in the tests just checked that `arccos` was in the numpy module and `acos` was not. Since numpy 2 added the aliases for the `a`-named versions of the `arc` functions, that test fails with numpy 2. Since `uncertainties` does not really need to test the names of functions in `numpy` that check is removed.

A future update could add the `acos()`-style aliases to `unumpy` as well.