### PR TITLE
add global TOC to doc index page

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -1,4 +1,4 @@
-<h5> Get <tt>uncertainties</tt></h5>
+<h4> Get <tt>uncertainties</tt></h4>
 <p>Current version: <b>{{ release }}</b></p>
 
 <p>
@@ -11,7 +11,7 @@
 </p>
 
 
- <h5>Offline Documentation</h5>
+ <h4>Offline Documentation</h4>
 
 <p>
   <a href="uncertainties.pdf">uncertainties.pdf</a>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -140,7 +140,7 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'index': ['indexsidebar.html',  'searchbox.html']}
+html_sidebars = {'index': ['indexsidebar.html',  'searchbox.html', 'globaltoc.html']}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
This adds a Table of Contents to the sidebar for the index page of the docs. 
See  https://lmfit.github.io/uncertainties/ for results