### PR TITLE
Ensure that GitHub Actions tests against the installed package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,11 +28,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install pytest pytest-cov numpy
+        python -m pip install -e .[arrays,test]
     - name: Test source code and docs
       run: |
         pytest --cov . --cov-report xml
+      env:
+        PYTHONSAFEPATH: "TRUE"
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,5 @@ doc = ["sphinx", "sphinx-copybutton", "python-docs-theme"]
 all = ["uncertainties[doc,test,arrays]"]
 
 [tool.pytest.ini_options]
+# import-mode = "importlib"
 testpaths = ["tests"]


### PR DESCRIPTION
PYTHONSAFEPATH=1 will prevent Python from loading the uncertainties files from the repo directory instead of loading them from site-packages (at least for Python >=3.11 when PYTHONSAFEPATH was added).

pytest's `import-mode=importlib` will prevent `pytest` from adding the working directory to the Python path.