### PR TITLE
Use explicit package list and ensure it is tested in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,8 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install pytest pytest-cov numpy
+        python -m pip install .[arrays,test]
     - name: Test source code and docs
       run: |
         pytest --cov . --cov-report xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,8 @@ classifiers = [
 ]
 dependencies = []
 
-[tool.setuptools.packages.find]
-include = ["uncertainties", "uncertainties.unumpy"]
-exclude = ["doc", "test"]
+[tool.setuptools]
+packages = ["uncertainties", "uncertainties.unumpy"]
 
 [project.urls]
 Documentation = "http://uncertainties-python-package.readthedocs.io/"


### PR DESCRIPTION
* In `pyproject.toml`, use an explicit package list instead of using the `find` directive.

* In GitHub Actions workflow, do not use an editable install since that implicitly includes all modules below `uncertainties/` and we want to make sure we test the package in its installed form.