### PR TITLE
update readthedocs_config to point to 'doc', and list requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,8 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
+  builder: "all"
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,6 +31,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+  python:
+    install:
+    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-copybutton
+python-docs-theme


### PR DESCRIPTION
This should fix the readthedocs configuration, solving the issue https://readthedocs.org/projects/uncertainties/builds/24572849/
pointed out by @andrewgsavage 