### PR TITLE
another RTD config fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,6 +27,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-  python:
-    install:
-    - requirements: doc/requirements.txt
+python:
+  install:
+  - requirements: doc/requirements.txt


### PR DESCRIPTION
OK, this time for sure!  See the discussion at #236 too.

One *can* enable RTD rendering on PRs: https://docs.readthedocs.io/en/stable/guides/pull-requests.html.  That needs Admin access to the RTD config, which only @lebigot has (maybe we can fix this?).  

In the meantime, I enabled RTD rendering on my own fork of uncertainties, and there I can set "build on PRs".  
With this PR, the docs do build, with results at https://test-uncertainties.readthedocs.io/en/latest/

I'll suggest that as a better approach to avoiding the sort of flailing around I was doing over the past couple of days:   

     when working on doc changes, enable test rendering of the RTD docs from a PR from 
     a personal fork and demonstrate that the build is successful as part of the  PR.





