### PR TITLE
use double backticks more uniformly

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -72,8 +72,8 @@ Basic math with uncertain Variables
 =========================================
 
 Uncertainties variables created in :func:`ufloat` or :func:`ufloat_fromstr` can
-be used in basic mathematical calculations ('+', '-', '*', '/', '**') as with
-other Python numbers and variables.
+be used in basic mathematical calculations (``+``, ``-``, ``*``, ``/``, ``**``)
+as with other Python numbers and variables.
 
 >>> t = ufloat(0.2, 0.01)
 >>> double = 2.0*t
@@ -160,18 +160,18 @@ are found in the :mod:`uncertainties.umath` module:
 
 The functions in the :mod:`uncertainties.umath` module include:
 
-    'acos', 'acosh', 'asin', 'asinh', 'atan', 'atan2', 'atanh',
-    'ceil', 'copysign', 'cos', 'cosh', 'degrees', 'erf', 'erfc',
-    'exp', 'expm1', 'fabs', 'factorial', 'floor', 'fmod',
-    'frexp', 'fsum', 'gamma', 'hypot', 'isinf', 'isnan',
-    'ldexp', 'lgamma', 'log', 'log10', 'log1p', 'modf',
-    'pow', 'radians', 'sin', 'sinh', 'sqrt', 'tan', 'tanh', 'trunc'
+    ``acos``, ``acosh``, ``asin``, ``asinh``, ``atan``, ``atan2``, ``atanh``,
+    ``ceil``, ``copysign``, ``cos``, ``cosh``, ``degrees``, ``erf``, ``erfc``,
+    ``exp``, ``expm1``, ``fabs``, ``factorial``, ``floor``, ``fmod``,
+    ``frexp``, ``fsum``, ``gamma``, ``hypot``, ``isinf``, ``isnan``,
+    ``ldexp``, ``lgamma``, ``log``, ``log10``, ``log1p``, ``modf``,
+    ``pow``, ``radians``, ``sin``, ``sinh``, ``sqrt``, ``tan``, ``tanh``, ``trunc``
 
 
 Comparison operators
 ====================
 
-Comparison operators ('==', '!=', '>', '<', '>=', and '<=') for Variables with
+Comparison operators (``==``, ``!=``, ``>``, ``<``, ``>=``, and ``<=``) for Variables with
 uncertainties are somewhat complicated, and need special attention.  As we
 hinted at above, and will explore in more detail below and in the
 :ref:`Technical Guide <comparison_operators>`, this relates to the correlation

--- a/uncertainties/__init__.py
+++ b/uncertainties/__init__.py
@@ -177,7 +177,7 @@ an approximate standard deviation of 0 (because the cosine is not well
 approximated by a line around 0), which might not be precise enough
 for all applications.
 
-- Comparison operations (>, ==, etc.) on numbers with uncertainties
+- Comparison operations (``>``, ``==``, etc.) on numbers with uncertainties
 have a pragmatic semantics, in this package: numbers with
 uncertainties can be used wherever Python numbers are used, most of
 the time with a result identical to the one that would be obtained
@@ -185,7 +185,7 @@ with their nominal value only.  However, since the objects defined in
 this module represent probability distributions and not pure numbers,
 comparison operator are interpreted in a specific way.
 
-The result of a comparison operation ("==", ">", etc.) is defined so as
+The result of a comparison operation (``==``, ``>``, etc.) is defined so as
 to be essentially consistent with the requirement that uncertainties
 be small: the value of a comparison operation is True only if the
 operation yields True for all infinitesimal variations of its random
@@ -204,7 +204,7 @@ is not such that x == y, since x and y are independent random
 variables that almost never give the same value.  However, x == x
 still holds.
 
-The boolean value (bool(x), "if x...") of a number with uncertainty x
+The boolean value (bool(x), ``if x...``) of a number with uncertainty x
 is the result of x != 0.
 
 - The uncertainties package is for Python 2.3 and above.


### PR DESCRIPTION
this changes single quotes to double backticks for operators and functions in the user guide, and in code comments. 

see discussion at https://github.com/lmfit/uncertainties/discussions/201#discussioncomment-9693130