### PR TITLE
version set to 3.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uncertainties"
-version = "3.2.0"
+version = "3.2.1"
 authors = [
     {name = "Eric O. LEBIGOT (EOL)", email = "eric.lebigot@normalesup.org"},
 ]

--- a/uncertainties/__init__.py
+++ b/uncertainties/__init__.py
@@ -226,7 +226,7 @@ from .core import *
 from .core import __all__  # For a correct help(uncertainties)
 
 # Numerical version:
-__version_info__ = (3, 2, 0)
+__version_info__ = (3, 2, 1)
 __version__ = '.'.join(map(str, __version_info__))
 
 __author__ = 'Eric O. LEBIGOT (EOL) <eric.lebigot@normalesup.org>'


### PR DESCRIPTION
this will set the version number to 3.2.1.

I checked the rendering of the docs, and double-checked that `tests/helpers.py` will be included in the `uncertainties-3.2.1.tar.gz` file that would be ready to upload to PyPI.