### PR TITLE
3.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-uncertainties-py23/
+uncertainties/version.py
 *.pyc
 build
 doc/_build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,28 @@
 Change Log
 ===================
 
+3.2.2   2024-July-08
+-----------------------
+
+Fixes:
+
+ - fix support for Numpy 2.0 (#245).  Note: `uncertainties.unumpy` still
+    provides `umatrix` based on `numpy.matrix`.  With `numpy.matrix`
+    discouraged, `umatrix` is too, and will be dropped in a  future release.
+ - fix automated running and reporting of code coverage with tests (#246)
+ - use `setuptools-scm` for setting version number from git tag  (#247)
+
+ 3.2.1   2024-June-08
+-----------------------
+
+Fixes for build, deployment, and docs
+
+ - Use explicit package list to make sure unumpy is included (#232)
+ - Use setuptools-scm to make sure all files are in the source distribution (#235)
+ - updates to configuration for and links to readthedocs documentation. (#239)
+ - use double backticks more uniformly in docs. (#240)
+ - fixes to README.rst to allow it to render (needed for PyPI upload) (#243)
+
 3.2.0   2024-June-02
 -----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,14 @@
 requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+write_to = "uncertainties/version.py"
+version_scheme = "post-release"
+
+
 [project]
 name = "uncertainties"
-version = "3.2.1"
+dynamic = ["version"]
 authors = [
     {name = "Eric O. LEBIGOT (EOL)", email = "eric.lebigot@normalesup.org"},
 ]
@@ -48,7 +53,6 @@ dependencies = []
 [tool.setuptools]
 packages = ["uncertainties", "uncertainties.unumpy"]
 
-[tool.setuptools_scm]
 
 [project.urls]
 Documentation = "https://uncertainties.readthedocs.io/"

--- a/uncertainties/__init__.py
+++ b/uncertainties/__init__.py
@@ -221,12 +221,11 @@ for bug reports, feature requests, or feedback.
 This software is released under the BSD license.
 '''
 
-from builtins import map
 from .core import *
 from .core import __all__  # For a correct help(uncertainties)
 
-# Numerical version:
-__version_info__ = (3, 2, 1)
-__version__ = '.'.join(map(str, __version_info__))
+from .version import __version__, __version_tuple__
+# for backward compatibility
+__version_info__ = __version_tuple__
 
 __author__ = 'Eric O. LEBIGOT (EOL) <eric.lebigot@normalesup.org>'


### PR DESCRIPTION
I think this should finalize version 3.2.2

It uses `setuptools-scm` for setting the version number from the git tag, which is much more convenient than updating `_init_.py` for each release.