### PR TITLE
have readthedocs install with , drop requirements files

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,4 +29,4 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-  - requirements: doc/requirements.txt
+  - pip install ".[all]"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,0 @@
-sphinx
-sphinx-copybutton
-python-docs-theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-numpy
-pytest
-pytest-cov
-sphinx


### PR DESCRIPTION
- [x] Closes #254
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file


This changes the readthedocs config to install uncertainties and dependencies with `pip install ".[all]"`.