### PR TITLE
Use packages to extract version information

### DIFF
--- a/uncertainties/__init__.py
+++ b/uncertainties/__init__.py
@@ -221,12 +221,16 @@ for bug reports, feature requests, or feedback.
 This software is released under the BSD license.
 """
 
+import importlib.metadata
+import packaging.version
+
+
 from .core import *  # noqa
 from .core import __all__  # noqa For a correct help(uncertainties)
 
-from .version import __version__, __version_tuple__  # noqa
 
-# for backward compatibility
-__version_info__ = __version_tuple__
+__version__ = importlib.metadata.version('uncertainties')
+__version_info__ = packaging.version.Version(__version__).release
+
 
 __author__ = "Eric O. LEBIGOT (EOL) <eric.lebigot@normalesup.org>"


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

- Use `importlib.metadata` to extract `__version__` and `packaging.version` to extract `__version_info__` tuple. In my opinion, this is an improvement over importing from the dynamically generated `version.py`. 

The goal here is to "single source" the version number. In this configuration with `setuptools_scm` the single source is the git tag. Package metadata is populated at build time and version information is extracted from there.