### PR TITLE
Make codecov pull requests informational only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,15 +1,8 @@
-codecov:
-  token: c2f0ce36-17ad-4668-bb1b-f1b72dedf3fc
-  comment:
-    after_n_builds: 9
-
 coverage:
-  precision: 2
-  round: down
-  range: "90...100"
   status:
     project:
       default:
-        target: auto
-        threshold: 2.0%
+        informational: true
+    patch:
+      default:
         informational: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,6 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
-        name: ${{ matrix.os }}-${{ matrix.python-version }}
         flags: ${{ matrix.os }}-${{ matrix.python-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -61,7 +60,6 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
-        name: no-numpy
         flags: no-numpy
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
-        flags: ${{ matrix.python-version }}, ${{ matrix.os }}
+        flags: ${{ matrix.os }}-${{ matrix.python-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_without_numpy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,6 +35,8 @@ jobs:
         python -m pytest --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
+      with:
+        flags: ${{ matrix.python-version }}, ${{ matrix.os }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_without_numpy:
@@ -45,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -57,6 +59,8 @@ jobs:
           --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
+      with:
+        flags: no_numpy
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   results:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,8 @@ jobs:
         python -m pip install .[arrays,test]
     - name: Test source code and docs
       run: |
-        python -m pytest --cov --cov-report xml --cov-report term
+        cd tests
+        python -m pytest --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
@@ -53,8 +54,9 @@ jobs:
         python -m pip install .[test]
     - name: Test source code and docs
       run:
-        python -m pytest --ignore tests/test_unumpy.py --ignore tests/test_ulinalg.py -k "not test_monte_carlo_comparison"
-          --cov --cov-report xml --cov-report term
+        cd tests;
+        python -m pytest --ignore=test_unumpy.py --ignore=test_ulinalg.py -k "not test_monte_carlo_comparison"
+          --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
-        flags: no_numpy
+        flags: no-numpy
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   results:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,8 @@ jobs:
         python -m pytest --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_without_numpy:
@@ -55,6 +57,8 @@ jobs:
           --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   results:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,8 +34,8 @@ jobs:
         python -m pytest --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_without_numpy:
     name: Test without numpy
     runs-on: ubuntu-latest
@@ -55,8 +55,8 @@ jobs:
           --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   results:
     # This step aggregates the results from all the tests and allows us to
     # require only this single job to pass for a PR to be merged rather than

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         file: ./coverage.xml
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: 02571ae7-4151-471b-b966-99394d268e29
   test_without_numpy:
     name: Test without numpy
     runs-on: ubuntu-latest
@@ -60,7 +60,8 @@ jobs:
       with:
         file: ./coverage.xml
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: 02571ae7-4151-471b-b966-99394d268e29
+
   results:
     # This step aggregates the results from all the tests and allows us to
     # require only this single job to pass for a PR to be merged rather than

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,6 +37,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: lmfit/uncertainties
+        file: coverage.xml
   test_without_numpy:
     name: Test without numpy
     runs-on: ubuntu-latest
@@ -52,13 +53,14 @@ jobs:
         python -m pip install .[test]
     - name: Test source code and docs
       run:
-        python -m pytest --ignore=test_unumpy.py --ignore=test_ulinalg.py -k "not test_monte_carlo_comparison"
-          --cov=uncertainties --cov --cov-report xml --cov-report term
+        python -m pytest --ignore tests/test_unumpy.py --ignore tests/test_ulinalg.py -k "not test_monte_carlo_comparison"
+          --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: lmfit/uncertainties
+        file: coverage.xml
   results:
     # This step aggregates the results from all the tests and allows us to
     # require only this single job to pass for a PR to be merged rather than

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
+        name: ${{ matrix.os }}-${{ matrix.python-version }}
         flags: ${{ matrix.os }}-${{ matrix.python-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -60,6 +61,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
       with:
+        name: no-numpy
         flags: no-numpy
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,8 +36,6 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        slug: lmfit/uncertainties
-        file: coverage.xml
   test_without_numpy:
     name: Test without numpy
     runs-on: ubuntu-latest
@@ -59,8 +57,6 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        slug: lmfit/uncertainties
-        file: coverage.xml
   results:
     # This step aggregates the results from all the tests and allows us to
     # require only this single job to pass for a PR to be merged rather than

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,8 +31,7 @@ jobs:
         python -m pip install .[arrays,test]
     - name: Test source code and docs
       run: |
-        cd tests
-        python -m pytest --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
+        python -m pytest --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:
@@ -53,9 +52,8 @@ jobs:
         python -m pip install .[test]
     - name: Test source code and docs
       run:
-        cd tests;
         python -m pytest --ignore=test_unumpy.py --ignore=test_ulinalg.py -k "not test_monte_carlo_comparison"
-          --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
+          --cov=uncertainties --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,8 +35,6 @@ jobs:
         python -m pytest --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
-      with:
-        file: ./coverage.xml
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_without_numpy:
@@ -59,11 +57,8 @@ jobs:
           --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.6.0
-      with:
-        file: ./coverage.xml
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   results:
     # This step aggregates the results from all the tests and allows us to
     # require only this single job to pass for a PR to be merged rather than

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4.6.0
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -33,7 +33,7 @@ jobs:
       run: |
         python -m pytest --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4.6.0
       with:
         file: ./coverage.xml
       env:
@@ -42,7 +42,7 @@ jobs:
     name: Test without numpy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.6.0
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -56,7 +56,7 @@ jobs:
         python -m pytest --ignore tests/test_unumpy.py --ignore tests/test_ulinalg.py -k "not test_monte_carlo_comparison"
           --cov --cov-report xml --cov-report term
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4.6.0
       with:
         file: ./coverage.xml
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         file: ./coverage.xml
       env:
-        CODECOV_TOKEN: 02571ae7-4151-471b-b966-99394d268e29
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_without_numpy:
     name: Test without numpy
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       with:
         file: ./coverage.xml
       env:
-        CODECOV_TOKEN: 02571ae7-4151-471b-b966-99394d268e29
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   results:
     # This step aggregates the results from all the tests and allows us to

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.6.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -42,7 +42,7 @@ jobs:
     name: Test without numpy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.6.0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         cd tests
         python -m pytest --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: lmfit/uncertainties
@@ -57,7 +57,7 @@ jobs:
         python -m pytest --ignore=test_unumpy.py --ignore=test_ulinalg.py -k "not test_monte_carlo_comparison"
           --cov=uncertainties --cov=. --cov-report=xml --cov-report=term
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: lmfit/uncertainties

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 Fixes:
 
 - fix `readthedocs` configuration so that the build passes (#254)
+- adjust `codecov.io` configuration so that minor code coverage changes will not result
+   in indications that tests are failing. Rather code coverage reports will be purely
+   informational for code reviewers. Also fix other minor configuration issues. (#270)
 
 3.2.2   2024-July-08
 -----------------------


### PR DESCRIPTION
- [x] Closes #270 
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This PR hopes to resolve a few issues with `uncertainty` package interaction with `codecov.io`. 

- #203 introduced `.codecov.yaml`. Unfortunately, I think this was an invalid configuration. Specifically because the `comment` section is supposed to be a top-level section, not nested under the `codecov` section. This means that since that PR the yaml configuration has NOT been used for our codecov updates. I think this explains why we're seeing codecov failures despite best attempts to suppress them.
- See for example #268 where a codecov failure is creating an X when we really just want the PR to go through. This PR will (attempt to) make it so that codecov coverage is reported, but will never result in a failed coverage run. This way reviewers can see if patch coverage is < 100% or if overall coverage drops due to a PR. If reviewers deem a lack or drop of coverage to be significant they can block PR approval. Otherwise, for minor coverage drops, the coverage can be easily ignored. It does so using the `informational` flag in the `.codecov.yaml` file.
- It moves the API token back to using the github secret rather than exposing it in the `.codecov.yaml` file.