### PR TITLE
unumpy array creation from string representation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Adds:
    O(N), rather than O(N^2), scaling complexity for operations involving many numbers
    with uncertainty. Established connectivity with `codspeed.io<codspeed.io>`_ to track
    benchmarking results. (#274)
+- Added a function `unumpy.uarray_fromstr` to create unumpy arrays from string
+   representations.
 
 
 Fixes:

--- a/doc/numpy_guide.rst
+++ b/doc/numpy_guide.rst
@@ -74,6 +74,13 @@ through NumPy, thanks to NumPy's support of arrays of arbitrary objects:
 
 >>> arr = numpy.array([ufloat(1, 0.1), ufloat(2, 0.002)])
 
+uarray Variables can also be created from a string representation. This follows the
+numpy convention, with square brackets and spaces separating the elements. A number of
+ufloat string representations are supported, as long as they do not contain any
+whitespace:
+
+>>> arr = unumpy.uarray_fromstr("[1.0+/-0.01 2.0+/-0.002]")
+
 .. index::
    single: matrices; creation and manipulation
    single: creation; matrices

--- a/doc/numpy_guide.rst
+++ b/doc/numpy_guide.rst
@@ -80,6 +80,12 @@ ufloat string representations are supported, as long as they do not contain any
 whitespace:
 
 >>> arr = unumpy.uarray_fromstr("[1.0+/-0.01 2.0+/-0.002]")
+>>> arr = unumpy.uarray_fromstr("[1.0(1) 2.0(2)]")
+>>> arr = unumpy.uarray_fromstr("[1.0+/-0.01 2.0(2) (6.283±0.002)E+02]")
+
+Creation from string representations of higher-dimensional arrays is also supported:
+
+>>> arr = unumpy.uarray_fromstr("[[1+/-1 2+/-2]\n [3+/-3 4+/-4]]")
 
 .. index::
    single: matrices; creation and manipulation

--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -311,7 +311,7 @@ def test_uarray_fromstr():
         "[1+/-0.1 2+/-0.2]": [(1, 0.1), (2, 0.2)],
         "[1.0+/-0.1 2.0+/-0.2]": [(1, 0.1), (2, 0.2)],
         # Global exponent:
-        "[(3.141+/-0.001)E+02 (6.283+/-0.002)E+02]": [(3.141, 0.001), (6.283, 0.002)],
+        "[(3.141+/-0.001)E+02 (6.283+/-0.002)E+02]": [(314.1, 0.1), (628.3, 0.2)],
         # Without uncertainties:
         "[25]": [(25, 1)],
         "[1 2 3]": [(1, 1), (2, 1), (3, 1)],
@@ -351,6 +351,6 @@ def test_uarray_fromstr():
         # With a tag as keyword argument:
         num_array = core.uarray_fromstr(representation, tag="test variable")
         for i, num in enumerate(num_array.flatten()):
-            assert numbers_close(num.nominal_value, values[0])
-            assert numbers_close(num.std_dev, values[1])
+            assert numbers_close(num.nominal_value, values[i][0])
+            assert numbers_close(num.std_dev, values[i][1])
             assert num.tag == "test variable"

--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -303,10 +303,10 @@ def test_array_comparisons():
 
 
 def test_uarray_fromstr():
-    "Test array creation from string representation"
+    "Test uarray creation from string representation"
 
-    # String representation, and numerical values:
-    tests = {
+    # 1D string representations, and numerical values:
+    tests_1D = {
         # Standard output from str(uarray):
         "[1+/-0.1 2+/-0.2]": [(1, 0.1), (2, 0.2)],
         "[1.0+/-0.1 2.0+/-0.2]": [(1, 0.1), (2, 0.2)],
@@ -333,7 +333,8 @@ def test_uarray_fromstr():
         "[-3(0.) 2(0.)]": [(-3, 0), (2, 0)],
     }
 
-    for representation, values in tests.items():
+    # Test the 1D representations:
+    for representation, values in tests_1D.items():
         # Without tag:
         num_array = core.uarray_fromstr(representation)
         for i, num in enumerate(num_array.flatten()):
@@ -354,3 +355,33 @@ def test_uarray_fromstr():
             assert numbers_close(num.nominal_value, values[i][0])
             assert numbers_close(num.std_dev, values[i][1])
             assert num.tag == "test variable"
+
+    # Higher dimensional arrays:
+    tests_ND = {
+        # 2D array:
+        "[[1+/-0.1 2+/-0.2]\n [3+/-0.3 4+/-0.4]]": numpy.array(
+            [
+                [(1, 0.1), (2, 0.2)],
+                [(3, 0.3), (4, 0.4)],
+            ],
+            dtype="f,f",
+        ),
+        # 3D array:
+        "[[[1+/-0.1 2+/-0.2]\n [3+/-0.3 4+/-0.4]]\n\n [[5+/-0.5 6+/-0.6]\n [7+/-0.7 8+/-0.8]]]": numpy.array(
+            [
+                [(1, 0.1), (2, 0.2)],
+                [(3, 0.3), (4, 0.4)],
+                [(5, 0.5), (6, 0.6)],
+                [(7, 0.7), (8, 0.8)],
+            ],
+            dtype="f,f",
+        ),
+    }
+
+    # Test the higher-dimensional representations:
+    for representation, values in tests_ND.items():
+        num_array = core.uarray_fromstr(representation)
+        for i, num in enumerate(num_array.flatten()):
+            assert numbers_close(num.nominal_value, values.flatten()[i][0])
+            assert numbers_close(num.std_dev, values.flatten()[i][1])
+            assert num.tag is None

--- a/uncertainties/unumpy/core.py
+++ b/uncertainties/unumpy/core.py
@@ -30,6 +30,7 @@ __all__ = [
     # Utilities:
     "nominal_values",
     "std_devs",
+    "uarray_fromstr",
     # Classes:
     "matrix",
 ]
@@ -115,6 +116,39 @@ def std_devs(arr):
     """
 
     return unumpy_to_numpy_matrix(to_std_devs(arr))
+
+
+def uarray_fromstr(representation, tag=None):
+    """
+    Create an uarray Variable from a string representation.
+
+    The string representation is expected to be a space-separated list of
+    ufloat representations, enclosed in square brackets.
+
+    The same ufloat representations as in ufloat_fromstr are accepted, except
+    representations containing spaces.
+
+    Arguments:
+    ----------
+    representation: string
+        string representation of an array of ufloat string representations
+    tag:   string or `None`
+        optional tag for tracing and organizing Variables ['None']
+
+    Returns:
+    --------
+    uarray Variable.
+
+    Examples:
+    -----------
+
+    >>> x = uarray_fromstr("[0.20+/-0.01 0.30+/-0.02]")  # = numpy.array([ufloat(0.20, 0.01), ufloat(0.30, 0.02)])
+    >>> x = uarray_fromstr("[0.20(1) 0.30(2)]")  # = numpy.array([ufloat(0.20, 0.01), ufloat(0.30, 0.02)])
+    >>> x = uarray_fromstr("[nan nan"])  # = numpy.array([ufloat(numpy.nan, 1.0), ufloat(numpy.nan, 1.0)])
+    """
+    values = representation.strip("[]").split()
+    values = [uncert_core.ufloat_fromstr(value, tag) for value in values]
+    return uarray(values)
 
 
 ###############################################################################


### PR DESCRIPTION
`uncertainties` has the very useful function `ufloat_fromstr` to create `ufloat` objects from various string representations. I thought that it would be a good symmetry to also include a `uarray_fromstr` function to turn string representations of *arrays* of `ufloat` string representations into `uarrays`. In particular, to re-create `uarray` objects from the results of `str(my_uarray)` (independent and  uncorrelated, of course).

```python
>>> import numpy as np
>>> from uncertainties import ufloat, unumpy as unp
>>> my_uarray = np.array([ufloat(2,1), ufloat(1.1,0.1)])
>>> my_str_rep = str(my_uarray)
>>> my_str_rep
'[2.0+/-1.0 1.1+/-0.1]'
>>> my_new_uarray = unp.uarray_fromstr(my_str_rep)
>>> unp.nominal_values(my_uarray) == unp.nominal_values(my_new_uarray)
array([ True,  True])
>>> unp.std_devs(my_uarray) == unp.std_devs(my_new_uarray)
array([ True,  True])
```

Implementing this has a few issues. Firstly, the string representations of `numpy` arrays use spaces to separate values. Therefore, string representations of ufloats that contain spaces (as supported by `ufloat_fromstr`) cannot (straightforwardly) be supported by `uarray_fromstr`.

`uarrays`, just like `numpy` arrays, can be multi-dimensional. In this case, the string representation will contain nested square brackets and newline characters. I have implemented `uarray_fromstr` to support this using [a slightly hacky workaround](https://stackoverflow.com/a/38887164) that relies on [`ast.literal_eval`](https://docs.python.org/3/library/ast.html#ast.literal_eval). While this is much safer than `eval`, there are still [some important security considerations](https://stackoverflow.com/a/7689085).

- [ ] Executed `pre-commit run --all-files` with no errors
- [X] The change is fully covered by automated unit tests
- [X] Documented in docs/ as appropriate
- [X] Added an entry to the CHANGES file
