### PR TITLE
Fix small float formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Fixes:
 - adjust `codecov.io` configuration so that minor code coverage changes will not result
    in indications that tests are failing. Rather code coverage reports will be purely
    informational for code reviewers. Also fix other minor configuration issues. (#270)
+- fixes to the str representation which occassionally errors when AffineScalarFunc is
+  too small (#135)
 
 3.2.2   2024-July-08
 -----------------------

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -26,6 +26,18 @@ def test_PDG_precision():
     for std_dev, result in tests.items():
         assert formatting.PDG_precision(std_dev) == result
 
+def test_small_float():
+    """
+    Make sure that very small floats do not error, even though printing as str
+    causes the number to be rounded to the nearest 324.
+    Suggested by issue #135.
+    """
+    a = 1e-324
+    b = 3e-324
+    assert a < b
+    str(ufloat(a, 0.0))
+    str(ufloat(b, 0.0))
+
 
 def test_repr():
     """Test the representation of numbers with uncertainty."""

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -26,6 +26,7 @@ def test_PDG_precision():
     for std_dev, result in tests.items():
         assert formatting.PDG_precision(std_dev) == result
 
+
 def test_small_float():
     """
     Make sure that very small floats do not error, even though printing as str

--- a/uncertainties/formatting.py
+++ b/uncertainties/formatting.py
@@ -1003,16 +1003,12 @@ def format_ufloat(ufloat_to_format, format_spec):
             # Common exponent *if* used:
             common_exp = first_digit(round(exp_ref_value, -digits_limit))
 
-            # print "COMMON EXP TEST VALUE", common_exp
-            # print "LIMIT EXP", common_exp-digits_limit+1
-            # print "WITH digits_limit", digits_limit
-
             # The number of significant digits of the reference value
             # rounded at digits_limit is exponent-digits_limit+1:
-            if -4 <= common_exp < common_exp - digits_limit + 1:
-                use_exp = False
-            else:
-                use_exp = True
+            use_exp = (
+                not (-4 <= common_exp < common_exp - digits_limit + 1)
+                and (factor := 10.0**common_exp) != 0.0
+            )
 
     ########################################
 

--- a/uncertainties/formatting.py
+++ b/uncertainties/formatting.py
@@ -995,9 +995,8 @@ def format_ufloat(ufloat_to_format, format_spec):
             # cases where this doesn't apply: too many digits when expressed like this,
             # or the common factor is way too small.
             if pres_type not in ("e", "E"):  # g, G, None
-                use_exp = (
-                    not (-4 <= common_exp < common_exp - digits_limit + 1)
-                    and (common_factor != 0.0)
+                use_exp = not (-4 <= common_exp < common_exp - digits_limit + 1) and (
+                    common_factor != 0.0
                 )
 
     ########################################


### PR DESCRIPTION
Fixed the edge case of having super-small (but non-zero) AffineFunc expressed as str.

- [x] Closes #135 
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
