### PR TITLE
Clean up `pow` tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,6 +5,13 @@ import uncertainties.core as uncert_core
 from uncertainties.core import ufloat, AffineScalarFunc
 
 
+def nan_close(first, second):
+    if isnan(first):
+        return isnan(second)
+    else:
+        return isclose(first, second)
+
+
 zero = ufloat(0, 0.1)
 zero2 = ufloat(0, 0.1)
 one = ufloat(1, 0.1)
@@ -30,26 +37,6 @@ power_derivative_cases = (
     (positive, zero, 0.0, -1.2039728043259361),
     (positive, negative, -1.4350387341664474, -1.7277476090907193),
 )
-
-
-def power_all_cases(op):
-    for (
-        first_ufloat,
-        second_ufloat,
-        first_der,
-        second_der,
-    ) in power_derivative_cases:
-        result = op(first_ufloat, second_ufloat)
-        first_der_result = result.derivatives[first_ufloat]
-        second_der_result = result.derivatives[second_ufloat]
-        if isnan(first_der):
-            assert isnan(first_der_result)
-        else:
-            assert isclose(first_der_result, first_der)
-        if isnan(second_der):
-            assert isnan(second_der_result)
-        else:
-            assert isclose(second_der_result, second_der)
 
 
 zero = ufloat(0, 0)
@@ -84,27 +71,16 @@ power_float_result_cases = [
 ]
 
 
-def power_special_cases(op):
-    for first, second, result in power_float_result_cases:
-        assert op(first, second) == result
+zero = ufloat(0, 0)
+positive = ufloat(0.3, 0.01)
+negative = ufloat(-0.3, 0.01)
 
 
-def power_wrt_ref(op, ref_op):
-    """
-    Checks special cases of the uncertainty power operator op (where
-    op is typically the built-in pow or uncertainties.umath.pow), by
-    comparing its results to the reference power operator ref_op
-    (which is typically the built-in pow or math.pow).
-    """
-
-    # Negative numbers with uncertainty can be exponentiated to an
-    # integral power:
-    assert op(ufloat(-1.1, 0.1), -9).nominal_value == ref_op(-1.1, -9)
-
-    # Case of numbers with no uncertainty: should give the same result
-    # as numbers with uncertainties:
-    assert op(ufloat(-1, 0), 9) == ref_op(-1, 9)
-    assert op(ufloat(-1.1, 0), 9) == ref_op(-1.1, 9)
+power_reference_cases = [
+    (ufloat(-1.1, 0.1), -9),
+    (ufloat(-1, 0), 9),
+    (ufloat(-1.1, 0), 9),
+]
 
 
 ###############################################################

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,30 +5,40 @@ import uncertainties.core as uncert_core
 from uncertainties.core import ufloat, AffineScalarFunc
 
 
+zero = ufloat(0, 0.1)
+zero2 = ufloat(0, 0.1)
+one = ufloat(1, 0.1)
+two = ufloat(2, 0.2)
+positive = ufloat(0.3, 0.01)
+positive2 = ufloat(0.3, 0.01)
+negative = ufloat(-0.3, 0.01)
+integer = ufloat(-3, 0)
+non_int_larger_than_one = ufloat(3.1, 0.01)
+positive_smaller_than_one = ufloat(0.3, 0.01)
+
+
 power_derivative_cases = (
-    ((-0.3, 0.01), (-3.0, 0.0), -370.37037037037044, float("nan")),
-    ((-0.3, 0.01), (1.0, 0.1), 1.0, float("nan")),
-    ((-0.3, 0.01), (0.0, 0.1), 0.0, float("nan")),
-    ((0.0, 0.1), (3.1, 0.01), float("nan"), 0.0),
-    ((0.0, 0.1), (1.0, 0.1), 1.0, 0.0),
-    ((0.0, 0.1), (2.0, 0.2), 0.0, 0.0),
-    ((0.0, 0.1), (0.3, 0.01), float("nan"), 0.0),
-    ((0.0, 0.1), (0.0, 0.1), 0.0, float("nan")),
-    ((0.3, 0.01), (0.3, 0.01), 0.696845301935949, -0.8389827923531782),
-    ((0.3, 0.01), (0.0, 0.1), 0.0, -1.2039728043259361),
-    ((0.3, 0.01), (-0.3, 0.01), -1.4350387341664474, -1.7277476090907193),
+    (negative, integer, -370.37037037037044, float("nan")),
+    (negative, one, 1.0, float("nan")),
+    (negative, zero, 0.0, float("nan")),
+    (zero, non_int_larger_than_one, float("nan"), 0.0),
+    (zero, one, 1.0, 0.0),
+    (zero, two, 0.0, 0.0),
+    (zero, positive_smaller_than_one, float("nan"), 0.0),
+    (zero, zero2, 0.0, float("nan")),
+    (positive, positive2, 0.696845301935949, -0.8389827923531782),
+    (positive, zero, 0.0, -1.2039728043259361),
+    (positive, negative, -1.4350387341664474, -1.7277476090907193),
 )
 
 
 def power_all_cases(op):
     for (
-        (first_val, first_std),
-        (second_val, second_std),
+        first_ufloat,
+        second_ufloat,
         first_der,
         second_der,
     ) in power_derivative_cases:
-        first_ufloat = ufloat(first_val, first_std)
-        second_ufloat = ufloat(second_val, second_std)
         result = op(first_ufloat, second_ufloat)
         first_der_result = result.derivatives[first_ufloat]
         second_der_result = result.derivatives[second_ufloat]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@ import random
 from math import isclose, isnan, isinf
 
 import uncertainties.core as uncert_core
-from uncertainties.core import ufloat, AffineScalarFunc
+from uncertainties.core import AffineScalarFunc
 
 
 def nan_close(first, second):
@@ -10,77 +10,6 @@ def nan_close(first, second):
         return isnan(second)
     else:
         return isclose(first, second)
-
-
-zero = ufloat(0, 0.1)
-zero2 = ufloat(0, 0.1)
-one = ufloat(1, 0.1)
-two = ufloat(2, 0.2)
-positive = ufloat(0.3, 0.01)
-positive2 = ufloat(0.3, 0.01)
-negative = ufloat(-0.3, 0.01)
-integer = ufloat(-3, 0)
-non_int_larger_than_one = ufloat(3.1, 0.01)
-positive_smaller_than_one = ufloat(0.3, 0.01)
-
-
-power_derivative_cases = (
-    (negative, integer, -370.37037037037044, float("nan")),
-    (negative, one, 1.0, float("nan")),
-    (negative, zero, 0.0, float("nan")),
-    (zero, non_int_larger_than_one, float("nan"), 0.0),
-    (zero, one, 1.0, 0.0),
-    (zero, two, 0.0, 0.0),
-    (zero, positive_smaller_than_one, float("nan"), 0.0),
-    (zero, zero2, 0.0, float("nan")),
-    (positive, positive2, 0.696845301935949, -0.8389827923531782),
-    (positive, zero, 0.0, -1.2039728043259361),
-    (positive, negative, -1.4350387341664474, -1.7277476090907193),
-)
-
-
-zero = ufloat(0, 0)
-one = ufloat(1, 0)
-p = ufloat(0.3, 0.01)
-
-power_float_result_cases = [
-    (0, p, 0),
-    (zero, p, 0),
-    (float("nan"), zero, 1),
-    (one, float("nan"), 1),
-    (p, 0, 1),
-    (zero, 0, 1),
-    (-p, 0, 1),
-    (-10.3, zero, 1),
-    (0, zero, 1),
-    (0.3, zero, 1),
-    (-p, zero, 1),
-    (zero, zero, 1),
-    (p, zero, 1),
-    (one, -3, 1),
-    (one, -3.1, 1),
-    (one, 0, 1),
-    (one, 3, 1),
-    (one, 3.1, 1),
-    (one, -p, 1),
-    (one, zero, 1),
-    (one, p, 1),
-    (1, -p, 1),
-    (1, zero, 1),
-    (1, p, 1),
-]
-
-
-zero = ufloat(0, 0)
-positive = ufloat(0.3, 0.01)
-negative = ufloat(-0.3, 0.01)
-
-
-power_reference_cases = [
-    (ufloat(-1.1, 0.1), -9),
-    (ufloat(-1, 0), 9),
-    (ufloat(-1.1, 0), 9),
-]
 
 
 ###############################################################

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -90,13 +90,8 @@ power_float_result_cases = [
     power_float_result_cases,
 )
 def test_power_float_result_cases(first_ufloat, second_ufloat, result_float):
-    assert pow(first_ufloat, second_ufloat) == result_float
-    assert umath_pow(first_ufloat, second_ufloat) == result_float
-
-
-zero = ufloat(0, 0)
-positive = ufloat(0.3, 0.01)
-negative = ufloat(-0.3, 0.01)
+    for op in [pow, umath_pow]:
+        assert op(first_ufloat, second_ufloat) == result_float
 
 
 power_reference_cases = [
@@ -108,13 +103,13 @@ power_reference_cases = [
 
 @pytest.mark.parametrize("first_ufloat, second_float", power_reference_cases)
 def test_power_wrt_ref(first_ufloat, second_float):
-    assert pow(first_ufloat, second_float).n == pow(first_ufloat.n, second_float)
-    assert umath_pow(first_ufloat, second_float).n == math_pow(
-        first_ufloat.n, second_float
-    )
+    test_op_ref_op_pairs = [(pow, pow), (umath_pow, math_pow)]
+    for test_op, ref_op in test_op_ref_op_pairs:
+        test_result = test_op(first_ufloat, second_float).n
+        ref_result = ref_op(first_ufloat.n, second_float)
+        assert test_result == ref_result
 
 
-zero = ufloat(0, 0)
 positive = ufloat(0.3, 0.01)
 negative = ufloat(-0.3, 0.01)
 power_exception_cases = [

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -1,0 +1,151 @@
+from math import pow as math_pow
+
+import pytest
+
+from uncertainties import ufloat
+from uncertainties.umath_core import pow as umath_pow
+
+from helpers import nan_close
+
+
+zero = ufloat(0, 0.1)
+zero2 = ufloat(0, 0.1)
+one = ufloat(1, 0.1)
+two = ufloat(2, 0.2)
+positive = ufloat(0.3, 0.01)
+positive2 = ufloat(0.3, 0.01)
+negative = ufloat(-0.3, 0.01)
+integer = ufloat(-3, 0)
+non_int_larger_than_one = ufloat(3.1, 0.01)
+positive_smaller_than_one = ufloat(0.3, 0.01)
+
+
+power_derivative_cases = (
+    (negative, integer, -370.37037037037044, float("nan")),
+    (negative, one, 1.0, float("nan")),
+    (negative, zero, 0.0, float("nan")),
+    (zero, non_int_larger_than_one, float("nan"), 0.0),
+    (zero, one, 1.0, 0.0),
+    (zero, two, 0.0, 0.0),
+    (zero, positive_smaller_than_one, float("nan"), 0.0),
+    (zero, zero2, 0.0, float("nan")),
+    (positive, positive2, 0.696845301935949, -0.8389827923531782),
+    (positive, zero, 0.0, -1.2039728043259361),
+    (positive, negative, -1.4350387341664474, -1.7277476090907193),
+)
+
+
+@pytest.mark.parametrize(
+    "first_ufloat, second_ufloat, first_der, second_der",
+    power_derivative_cases,
+)
+def test_power_derivatives(first_ufloat, second_ufloat, first_der, second_der):
+    result = pow(first_ufloat, second_ufloat)
+    first_der_result = result.derivatives[first_ufloat]
+    second_der_result = result.derivatives[second_ufloat]
+    assert nan_close(first_der_result, first_der)
+    assert nan_close(second_der_result, second_der)
+
+    result = umath_pow(first_ufloat, second_ufloat)
+    first_der_result = result.derivatives[first_ufloat]
+    second_der_result = result.derivatives[second_ufloat]
+    assert nan_close(first_der_result, first_der)
+    assert nan_close(second_der_result, second_der)
+
+
+zero = ufloat(0, 0)
+one = ufloat(1, 0)
+p = ufloat(0.3, 0.01)
+
+power_float_result_cases = [
+    (0, p, 0),
+    (zero, p, 0),
+    (float("nan"), zero, 1),
+    (one, float("nan"), 1),
+    (p, 0, 1),
+    (zero, 0, 1),
+    (-p, 0, 1),
+    (-10.3, zero, 1),
+    (0, zero, 1),
+    (0.3, zero, 1),
+    (-p, zero, 1),
+    (zero, zero, 1),
+    (p, zero, 1),
+    (one, -3, 1),
+    (one, -3.1, 1),
+    (one, 0, 1),
+    (one, 3, 1),
+    (one, 3.1, 1),
+    (one, -p, 1),
+    (one, zero, 1),
+    (one, p, 1),
+    (1, -p, 1),
+    (1, zero, 1),
+    (1, p, 1),
+]
+
+
+@pytest.mark.parametrize(
+    "first_ufloat, second_ufloat, result_float",
+    power_float_result_cases,
+)
+def test_power_float_result_cases(first_ufloat, second_ufloat, result_float):
+    assert pow(first_ufloat, second_ufloat) == result_float
+    assert umath_pow(first_ufloat, second_ufloat) == result_float
+
+
+zero = ufloat(0, 0)
+positive = ufloat(0.3, 0.01)
+negative = ufloat(-0.3, 0.01)
+
+
+power_reference_cases = [
+    (ufloat(-1.1, 0.1), -9),
+    (ufloat(-1, 0), 9),
+    (ufloat(-1.1, 0), 9),
+]
+
+
+@pytest.mark.parametrize("first_ufloat, second_float", power_reference_cases)
+def test_power_wrt_ref(first_ufloat, second_float):
+    assert pow(first_ufloat, second_float).n == pow(first_ufloat.n, second_float)
+    assert umath_pow(first_ufloat, second_float).n == math_pow(
+        first_ufloat.n, second_float
+    )
+
+
+zero = ufloat(0, 0)
+positive = ufloat(0.3, 0.01)
+negative = ufloat(-0.3, 0.01)
+power_exception_cases = [
+    (ufloat(0, 0), negative, ZeroDivisionError),
+    (ufloat(0, 0.1), negative, ZeroDivisionError),
+    (negative, positive, ValueError),
+]
+
+
+@pytest.mark.parametrize("first_ufloat, second_ufloat, exc_type", power_exception_cases)
+def test_power_exceptions(first_ufloat, second_ufloat, exc_type):
+    with pytest.raises(exc_type):
+        pow(first_ufloat, second_ufloat)
+
+
+"""
+math.pow raises ValueError in these cases, in contrast to pow which raises
+ZeroDivisionError so these test cases are slightly different than those that appear for
+test_power_exceptions in test_uncertainties.py.
+"""
+umath_power_exception_cases = [
+    (ufloat(0, 0), negative, ValueError),
+    (ufloat(0, 0.1), negative, ValueError),
+    (negative, positive, ValueError),
+]
+
+
+@pytest.mark.parametrize(
+    "first_ufloat, second_ufloat, exc_type",
+    umath_power_exception_cases,
+)
+def test_umath_power_exceptions(first_ufloat, second_ufloat, exc_type):
+    with pytest.raises(exc_type):
+        umath_pow(first_ufloat, second_ufloat)

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -1,18 +1,13 @@
 import math
 from math import isnan
 
-import pytest
 
 from uncertainties import ufloat
 import uncertainties.core as uncert_core
 import uncertainties.umath_core as umath_core
 
 from helpers import (
-    power_derivative_cases,
-    power_float_result_cases,
-    power_reference_cases,
     compare_derivatives,
-    nan_close,
     numbers_close,
 )
 ###############################################################################
@@ -279,51 +274,3 @@ def test_hypot():
     result = umath_core.hypot(x, y)
     assert isnan(result.derivatives[x])
     assert isnan(result.derivatives[y])
-
-
-@pytest.mark.parametrize(
-    "first_ufloat, second_ufloat, first_der, second_der",
-    power_derivative_cases,
-)
-def test_power_derivatives(first_ufloat, second_ufloat, first_der, second_der):
-    result = umath_core.pow(first_ufloat, second_ufloat)
-    first_der_result = result.derivatives[first_ufloat]
-    second_der_result = result.derivatives[second_ufloat]
-    assert nan_close(first_der_result, first_der)
-    assert nan_close(second_der_result, second_der)
-
-
-@pytest.mark.parametrize(
-    "first_ufloat, second_ufloat, result_float",
-    power_float_result_cases,
-)
-def test_power_float_result_cases(first_ufloat, second_ufloat, result_float):
-    assert umath_core.pow(first_ufloat, second_ufloat) == result_float
-
-
-zero = ufloat(0, 0)
-positive = ufloat(0.3, 0.01)
-negative = ufloat(-0.3, 0.01)
-"""
-math.pow raises ValueError in these cases, in contrast to pow which raises
-ZeroDivisionError so these test cases are slightly different than those that appear for
-test_power_exceptions in test_uncertainties.py.
-"""
-power_exception_cases = [
-    (ufloat(0, 0), negative, ValueError),
-    (ufloat(0, 0.1), negative, ValueError),
-    (negative, positive, ValueError),
-]
-
-
-@pytest.mark.parametrize("first_ufloat, second_ufloat, exc_type", power_exception_cases)
-def test_power_exceptions(first_ufloat, second_ufloat, exc_type):
-    with pytest.raises(exc_type):
-        umath_core.pow(first_ufloat, second_ufloat)
-
-
-@pytest.mark.parametrize("first_ufloat, second_float", power_reference_cases)
-def test_power_wrt_ref(first_ufloat, second_float):
-    expected_result = math.pow(first_ufloat.n, second_float)
-    actual_result = umath_core.pow(first_ufloat, second_float).n
-    assert actual_result == expected_result

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -13,10 +13,6 @@ from uncertainties import (
     correlation_matrix,
 )
 from helpers import (
-    power_derivative_cases,
-    power_float_result_cases,
-    power_reference_cases,
-    nan_close,
     numbers_close,
     ufloats_close,
     compare_derivatives,
@@ -1050,53 +1046,6 @@ def test_covariances():
     assert numbers_close(covs[2][2], 0.09)
     # Non-diagonal elements:
     assert numbers_close(covs[0][1], -0.02)
-
-
-###############################################################################
-
-
-@pytest.mark.parametrize(
-    "first_ufloat, second_ufloat, first_der, second_der",
-    power_derivative_cases,
-)
-def test_power_derivatives(first_ufloat, second_ufloat, first_der, second_der):
-    result = pow(first_ufloat, second_ufloat)
-    first_der_result = result.derivatives[first_ufloat]
-    second_der_result = result.derivatives[second_ufloat]
-    assert nan_close(first_der_result, first_der)
-    assert nan_close(second_der_result, second_der)
-
-
-@pytest.mark.parametrize(
-    "first_ufloat, second_ufloat, result_float",
-    power_float_result_cases,
-)
-def test_power_float_result_cases(first_ufloat, second_ufloat, result_float):
-    assert pow(first_ufloat, second_ufloat) == result_float
-
-
-zero = ufloat(0, 0)
-positive = ufloat(0.3, 0.01)
-negative = ufloat(-0.3, 0.01)
-power_exception_cases = [
-    (ufloat(0, 0), negative, ZeroDivisionError),
-    (ufloat(0, 0.1), negative, ZeroDivisionError),
-    (negative, positive, ValueError),
-]
-
-
-@pytest.mark.parametrize("first_ufloat, second_ufloat, exc_type", power_exception_cases)
-def test_power_exceptions(first_ufloat, second_ufloat, exc_type):
-    with pytest.raises(exc_type):
-        pow(first_ufloat, second_ufloat)
-
-
-@pytest.mark.parametrize("first_ufloat, second_float", power_reference_cases)
-def test_power_wrt_ref(first_ufloat, second_float):
-    assert pow(first_ufloat, second_float).n == pow(first_ufloat.n, second_float)
-
-
-###############################################################################
 
 
 ###############################################################################


### PR DESCRIPTION
- [x] Closes #291
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Summary of goals:

- Changes all power tests to use `pytest.mark.parametrize`. Hopefully this makes the tests more readable. 
- Combines the tests for `pow` and `umath_core.pow` in a `test_power.py` module to get some code re-use and to combine similar tests rather than spread them across modules
- Remove `pow` test code from `helpers.py` module.