### PR TITLE
Add deprecation warnings for `umath` functions and `UFloat` methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,9 +38,9 @@ Deprecates:
 - Certain `umath` functions and `AffineScalarFunc`/`UFloat` methods will be removed in
    a future release. A deprecation warning has been added to these functions and
    methods. The following `umath` functions are marked as deprecated: `ceil`,
-   `copysign`, `isinf`, `isnan`, `fabs`, `factorial`, `floor`, `fmod`, `frexp`, `ldexp`,
-   `modf`, `trunc`. The following `AffineScalarFunc`/`UFloat` methods are marked as
-   deprecated: `__floordiv__`, `__mod__`, `__abs__`, `__trunc__`.
+   `copysign`, `fabs`, `factorial`, `floor`, `fmod`, `frexp`, `ldexp`, `modf`, `trunc`.
+   The following `AffineScalarFunc`/`UFloat` methods are marked as deprecated:
+   `__floordiv__`, `__mod__`, `__abs__`, `__trunc__`.
 
 3.2.2   2024-July-08
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,15 @@ Fixes:
 - fixes to the str representation which occassionally errors when AffineScalarFunc is
   too small (#135)
 
+Deprecates:
+
+- Certain `umath` functions and `AffineScalarFunc`/`UFloat` methods will be removed in
+   a future release. A deprecation warning has been added to these functions and
+   methods. The following `umath` functions are marked as deprecated: `ceil`,
+   `copysign`, `isinf`, `isnan`, `fabs`, `factorial`, `floor`, `fmod`, `frexp`, `ldexp`,
+   `modf`, `trunc`. The following `AffineScalarFunc`/`UFloat` methods are marked as
+   deprecated: `__floordiv__`, `__mod__`, `__abs__`, `__trunc__`.
+
 3.2.2   2024-July-08
 -----------------------
 

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -1,6 +1,8 @@
+import inspect
 import math
 from math import isnan
 
+import pytest
 
 from uncertainties import ufloat
 import uncertainties.core as uncert_core
@@ -274,3 +276,19 @@ def test_hypot():
     result = umath_core.hypot(x, y)
     assert isnan(result.derivatives[x])
     assert isnan(result.derivatives[y])
+
+
+@pytest.mark.parametrize("function_name", umath_core.deprecated_functions)
+def test_deprecated_function(function_name):
+    num_args = len(inspect.signature(getattr(math, function_name)).parameters)
+    args = [ufloat(1, 0.1)]
+    if num_args == 1:
+        if function_name == "factorial":
+            args[0] = 6
+    else:
+        if function_name == "ldexp":
+            args.append(3)
+        else:
+            args.append(ufloat(-12, 2.4))
+    with pytest.warns(FutureWarning, match="will be removed"):
+        getattr(umath_core, function_name)(*args)

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -1,11 +1,17 @@
 import copy
+import inspect
 import math
 import random  # noqa
 
 import pytest
 
 import uncertainties.core as uncert_core
-from uncertainties.core import ufloat, AffineScalarFunc, ufloat_fromstr
+from uncertainties.core import (
+    ufloat,
+    AffineScalarFunc,
+    ufloat_fromstr,
+    deprecated_methods,
+)
 from uncertainties import (
     umath,
     correlated_values,
@@ -1299,3 +1305,15 @@ def test_no_numpy():
         match="not able to import numpy",
     ):
         _ = correlation_matrix([x, y, z])
+
+
+@pytest.mark.parametrize("method_name", deprecated_methods)
+def test_deprecated_method(method_name):
+    x = ufloat(1, 0.1)
+    y = ufloat(-12, 2.4)
+    num_args = len(inspect.signature(getattr(float, method_name)).parameters)
+    with pytest.warns(FutureWarning, match="will be removed"):
+        if num_args == 1:
+            getattr(x, method_name)()
+        else:
+            getattr(x, method_name)(y)

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1054,7 +1054,7 @@ def ufloat(nominal_value, std_dev=None, tag=None):
 def deprecation_wrapper(func, msg):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-        warn(msg, FutureWarning)
+        warn(msg, FutureWarning, stacklevel=2)
         return func(*args, **kwargs)
 
     return wrapped

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -15,7 +15,9 @@ Main module for the uncertainties package, with internal functions.
 from __future__ import division  # Many analytical derivatives depend on this
 
 from builtins import str, zip, range, object
+import functools
 from math import sqrt, isfinite  # Optimization: no attribute look-up
+from warnings import warn
 
 import copy
 import collections
@@ -1044,3 +1046,34 @@ def ufloat(nominal_value, std_dev=None, tag=None):
     """
 
     return Variable(nominal_value, std_dev, tag=tag)
+
+
+# Deprecated UFloat methods
+
+
+def deprecation_wrapper(func, msg):
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        warn(msg, FutureWarning)
+        return func(*args, **kwargs)
+
+    return wrapped
+
+
+deprecated_methods = [
+    "__floordiv__",
+    "__mod__",
+    "__abs__",
+    "__trunc__",
+]
+
+for method_name in deprecated_methods:
+    message = (
+        f"AffineScalarFunc.{method_name}() is deprecated. It will be removed in a future "
+        f"release."
+    )
+    setattr(
+        AffineScalarFunc,
+        method_name,
+        deprecation_wrapper(getattr(AffineScalarFunc, method_name), message),
+    )

--- a/uncertainties/umath_core.py
+++ b/uncertainties/umath_core.py
@@ -424,6 +424,38 @@ def frexp(x):
 
 non_std_wrapped_funcs.append("frexp")
 
+# Deprecated functions
+
+deprecated_functions = [
+    "ceil",
+    "copysign",
+    "isinf",
+    "isnan",
+    "fabs",
+    "factorial",
+    "floor",
+    "fmod",
+    "frexp",
+    "ldexp",
+    "modf",
+    "trunc",
+]
+
+for function_name in deprecated_functions:
+    message = (
+        f"umath.{function_name}() is deprecated. It will be removed in a future "
+        f"release."
+    )
+    setattr(
+        this_module,
+        function_name,
+        uncert_core.deprecation_wrapper(
+            getattr(this_module, function_name),
+            message,
+        ),
+    )
+
+
 ###############################################################################
 # Exported functions:
 

--- a/uncertainties/umath_core.py
+++ b/uncertainties/umath_core.py
@@ -429,8 +429,6 @@ non_std_wrapped_funcs.append("frexp")
 deprecated_functions = [
     "ceil",
     "copysign",
-    "isinf",
-    "isnan",
     "fabs",
     "factorial",
     "floor",


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Add deprecation warnings for various `UFloat` methods and `umath` functions. See the list of deprecated methods/functions in the source code and see also #295.