### PR TITLE
Mark comparison operations as deprecated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,7 +40,8 @@ Deprecates:
    methods. The following `umath` functions are marked as deprecated: `ceil`,
    `copysign`, `fabs`, `factorial`, `floor`, `fmod`, `frexp`, `ldexp`, `modf`, `trunc`.
    The following `AffineScalarFunc`/`UFloat` methods are marked as deprecated:
-   `__floordiv__`, `__mod__`, `__abs__`, `__trunc__`.
+   `__floordiv__`, `__mod__`, `__abs__`, `__trunc__`, `__lt__`, `__le__`, `__gt__`,
+   `__ge__`.
 
 3.2.2   2024-July-08
 -----------------------

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1039,6 +1039,10 @@ deprecated_methods = [
     "__mod__",
     "__abs__",
     "__trunc__",
+    "__lt__",
+    "__gt__",
+    "__le__",
+    "__ge__",
 ]
 
 for method_name in deprecated_methods:


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

See the discussion at #295. 

Right now the `<` and `>` operators apply direct comparison on the nominal values of the two `UFloat`s or `UFloat` and `float` involved. However, the `==` operator between `x` and `y` checks that, both the nominal value AND standard deviation of `x-y` is zero. This means that the nominal values are equal and the two variables are fully correlated.

The main reasons for removing `<, >` from `UFloat are

- Real number follow [the law of trichotomy](https://en.wikipedia.org/wiki/Law_of_trichotomy) which says that for any two real numbers `x` and `y` it is the case that exactly one of `x<y`, `x==y` or `x>y` is `True`. We typically expect orders that appear in scientific computing to follow this law. However, this law is not obeyed by `UFloat`. If `x=UFloat(1, 0.1)` and `y=UFloat(1, 0.2)` then `x<y`, `x==y` and `x>y` are all `False`. This is a surprising behavior.
- We are moving towards more tightly adhering the `UFloat` class to serving as a model of a mathematical [random variable](https://en.wikipedia.org/wiki/Random_variable). Random variables do not an ordering on them. Indeed, if `X` and `Y` are random variables then on one sampling/realization resulting in `x`/`y` as samples of `X` and `Y` we may have `x<y`, but on another sampling we may have `x>y`. So, since there is no ordering on random variables, there should be no ordering on `UFloat`.

If users do want to compare the value of the mean value of the random variables, i.e. the `nominal_value` attributed, then they should do so explicitly using `x.n < y.n`.