### PR TITLE
Raise a warning for `std_dev==0`

### DIFF
--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -1330,3 +1330,8 @@ def test_deprecated_method(method_name):
             getattr(x, method_name)()
         else:
             getattr(x, method_name)(y)
+
+
+def test_zero_std_dev_warn():
+    with pytest.warns(UserWarning, match="std_dev==0.*unexpected results"):
+        ufloat(1, 0)

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1018,7 +1018,11 @@ def ufloat(nominal_value, std_dev=None, tag=None):
     3. The returned Variable will have attributes `nominal_value`, `std_dev`,
        and `tag` which match the input values.
     """
-
+    if std_dev == 0:
+        warn(
+            "Certain operations may give unexpected results for UFloat objects with "
+            "std_dev==0."
+        )
     return Variable(nominal_value, std_dev, tag=tag)
 
 

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1019,10 +1019,7 @@ def ufloat(nominal_value, std_dev=None, tag=None):
        and `tag` which match the input values.
     """
     if std_dev == 0:
-        warn(
-            "Certain operations may give unexpected results for UFloat objects with "
-            "std_dev==0."
-        )
+        warn("Using UFloat objects with std_dev==0 may give unexpected results.")
     return Variable(nominal_value, std_dev, tag=tag)
 
 


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Raises a warning when a user calls `ufloat` with `std_dev==0`.
See #283 and #295 for further discussion.