### PR TITLE
Increase the stacklevel of the std_dev==0 warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change Log
 Unreleased
 ----------
 
+- Increases the stacklevel of the warning about `std_dev==0` so that it blames
+  the caller rather than blaming the `ufloat()` function.
+
 3.2.3   2025-April-18
 -----------------------
 

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1021,7 +1021,10 @@ def ufloat(nominal_value, std_dev=None, tag=None):
        and `tag` which match the input values.
     """
     if std_dev == 0:
-        warn("Using UFloat objects with std_dev==0 may give unexpected results.")
+        warn(
+            "Using UFloat objects with std_dev==0 may give unexpected results.",
+            stacklevel=2,
+        )
     return Variable(nominal_value, std_dev, tag=tag)
 
 


### PR DESCRIPTION
With this change, the warning will show the caller's location instead of the location in `ufloat()` where the warning is generated.

I ran into some std_dev==0 warnings in a project I work on, partly from lmfit (like reported [here](https://github.com/lmfit/lmfit-py/issues/999)) and partly local to the project (reporting parameter sets uniformly as `UFloat` whether or not they have uncertainty). The `ufloat()` calls are made many levels deep in the code so it was hard to tell where they were coming from (I put a break point on the warning with a debugger). I think incrementing the stack level so the caller is blamed for the warning is helpful.

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
