### PR TITLE
Improve "is close" testing

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,13 +1,16 @@
-from math import isclose, isnan, isinf
+from math import isclose, isnan
 
-import uncertainties.core as uncert_core
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 
-def nan_close(first, second):
+def nan_close(first, second, *, rel_tol=1e-9, abs_tol=0.0):
     if isnan(first):
         return isnan(second)
     else:
-        return isclose(first, second)
+        return isclose(first, second, rel_tol=rel_tol, abs_tol=abs_tol)
 
 
 ###############################################################
@@ -17,35 +20,7 @@ def nan_close(first, second):
 # Utilities for unit testing
 
 
-def numbers_close(x, y, tolerance=1e-6):
-    """
-    Returns True if the given floats are close enough.
-
-    The given tolerance is the relative difference allowed, or the absolute
-    difference, if one of the numbers is 0.
-
-    NaN is allowed: it is considered close to itself.
-    """
-
-    # !!! Python 3.5+ has math.isclose(): maybe it could be used here.
-
-    # Instead of using a try and ZeroDivisionError, we do a test,
-    # NaN could appear silently:
-
-    if x != 0 and y != 0:
-        if isinf(x):
-            return isinf(y)
-        elif isnan(x):
-            return isnan(y)
-        else:
-            # Symmetric form of the test:
-            return 2 * abs(x - y) / (abs(x) + abs(y)) < tolerance
-
-    else:  # Either x or y is zero
-        return abs(x or y) < tolerance
-
-
-def ufloats_close(x, y, tolerance=1e-6):
+def ufloat_nan_close(x, y, tolerance=1e-6):
     """
     Tests if two numbers with uncertainties are close, as random
     variables: this is stronger than testing whether their nominal
@@ -56,9 +31,19 @@ def ufloats_close(x, y, tolerance=1e-6):
     """
 
     diff = x - y
-    return numbers_close(diff.nominal_value, 0, tolerance) and numbers_close(
-        diff.std_dev, 0, tolerance
+    nominal_values_close = nan_close(
+        diff.n,
+        0,
+        rel_tol=tolerance,
+        abs_tol=tolerance,
     )
+    std_devs_close = nan_close(
+        diff.s,
+        0,
+        rel_tol=tolerance,
+        abs_tol=tolerance,
+    )
+    return nominal_values_close and std_devs_close
 
 
 ###############################################################################
@@ -84,21 +69,19 @@ else:
         precision -- precision passed through to
         uncertainties.test_uncertainties.numbers_close().
         """
-
-        # ! numpy.allclose() is similar to this function, but does not
-        # work on arrays that contain numbers with uncertainties, because
-        # of the isinf() function.
-
-        for elmt1, elmt2 in zip(m1.flat, m2.flat):
-            # For a simpler comparison, both elements are
-            # converted to AffineScalarFunc objects:
-            elmt1 = uncert_core.to_affine_scalar(elmt1)
-            elmt2 = uncert_core.to_affine_scalar(elmt2)
-
-            if not numbers_close(elmt1.nominal_value, elmt2.nominal_value, precision):
-                return False
-
-            if not numbers_close(elmt1.std_dev, elmt2.std_dev, precision):
-                return False
-
-        return True
+        diff_arr = m1 - m2
+        nominal_values_arr = np.vectorize(lambda x: x.n)(diff_arr)
+        std_devs_arr = np.vectorize(lambda x: x.s)(diff_arr)
+        nominal_values_close_arr = np.isclose(
+            nominal_values_arr,
+            0,
+            rtol=precision,
+            atol=precision,
+        )
+        std_devs_close_arr = np.isclose(
+            std_devs_arr,
+            0,
+            rtol=precision,
+            atol=precision,
+        )
+        return np.logical_and(nominal_values_close_arr, std_devs_close_arr)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,10 +1,5 @@
 from math import isclose, isnan
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
-
 
 def nan_close(first, second, *, rel_tol=1e-9, abs_tol=0.0):
     if isnan(first):
@@ -50,7 +45,7 @@ def ufloat_nan_close(x, y, tolerance=1e-6):
 
 
 try:
-    import numpy  # noqa
+    import numpy as np  # noqa
 except ImportError:
     pass
 else:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,8 +1,7 @@
 import pytest
 
 from uncertainties import ufloat, ufloat_fromstr, formatting
-
-from helpers import numbers_close
+from helpers import nan_close
 
 
 def test_PDG_precision():
@@ -486,10 +485,12 @@ def test_format(val, std_dev, fmt_spec, expected_str):
         relative error is infinite, so this should not cause an error:
         """
         if x_back.nominal_value:
-            assert numbers_close(x.nominal_value, x_back.nominal_value, 2.4e-1)
+            assert nan_close(
+                x.nominal_value, x_back.nominal_value, rel_tol=2.4e-1, abs_tol=2.4e-1
+            )
 
         # If the uncertainty is zero, then the relative change can be large:
-        assert numbers_close(x.std_dev, x_back.std_dev, 3e-1)
+        assert nan_close(x.std_dev, x_back.std_dev, rel_tol=3e-1, abs_tol=3e-1)
 
 
 def test_unicode_format():

--- a/tests/test_ulinalg.py
+++ b/tests/test_ulinalg.py
@@ -49,7 +49,7 @@ def test_list_inverse():
     # Internal consistency: ulinalg.inv() must coincide with the
     # unumpy.matrix inverse, for square matrices (.I is the
     # pseudo-inverse, for non-square matrices, but inv() is not).
-    assert uarrays_close(unumpy.ulinalg.inv(mat), mat.I)
+    assert uarrays_close(unumpy.ulinalg.inv(mat), mat.I).all()
 
 
 def test_list_pseudo_inverse():
@@ -61,14 +61,14 @@ def test_list_pseudo_inverse():
 
     # Internal consistency: the inverse and the pseudo-inverse yield
     # the same result on square matrices:
-    assert uarrays_close(mat.I, unumpy.ulinalg.pinv(mat), 1e-4)
+    assert uarrays_close(mat.I, unumpy.ulinalg.pinv(mat), 1e-4).all()
     assert uarrays_close(
         unumpy.ulinalg.inv(mat),
         # Support for the optional pinv argument is
         # tested:
         unumpy.ulinalg.pinv(mat, 1e-15),
         1e-4,
-    )
+    ).all()
 
     # Non-square matrices:
     x = ufloat(1, 0.1)
@@ -77,5 +77,5 @@ def test_list_pseudo_inverse():
     mat2 = unumpy.matrix([[x, y], [1, 3 + x], [y, 2 * x]])  # "Tall" matrix
 
     # Internal consistency:
-    assert uarrays_close(mat1.I, unumpy.ulinalg.pinv(mat1, 1e-10))
-    assert uarrays_close(mat2.I, unumpy.ulinalg.pinv(mat2, 1e-8))
+    assert uarrays_close(mat1.I, unumpy.ulinalg.pinv(mat1, 1e-10)).all()
+    assert uarrays_close(mat2.I, unumpy.ulinalg.pinv(mat2, 1e-8)).all()

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -11,7 +11,7 @@ import uncertainties.core as uncert_core
 import uncertainties.umath_core as umath_core
 from uncertainties.ops import partial_derivative
 
-from helpers import numbers_close
+from helpers import nan_close
 ###############################################################################
 # Unit tests
 
@@ -156,8 +156,11 @@ def test_monte_carlo_comparison():
     # or assert_array_max_ulp. This is relevant for all vectorized
     # occurrences of numbers_close.
 
-    assert numpy.vectorize(numbers_close)(
-        covariances_this_module, covariances_samples, 0.06
+    assert numpy.vectorize(nan_close)(
+        covariances_this_module,
+        covariances_samples,
+        rel_tol=0.06,
+        abs_tol=0.06,
     ).all(), (
         "The covariance matrices do not coincide between"
         " the Monte-Carlo simulation and the direct calculation:\n"
@@ -166,13 +169,13 @@ def test_monte_carlo_comparison():
     )
 
     # The nominal values must be close:
-    assert numbers_close(
+    assert nan_close(
         nominal_value_this_module,
         nominal_value_samples,
         # The scale of the comparison depends on the standard
         # deviation: the nominal values can differ by a fraction of
         # the standard deviation:
-        math.sqrt(covariances_samples[2, 2]) / abs(nominal_value_samples) * 0.5,
+        rel_tol=math.sqrt(covariances_samples[2, 2]) / abs(nominal_value_samples) * 0.5,
     ), (
         "The nominal value (%f) does not coincide with that of"
         " the Monte-Carlo simulation (%f), for a standard deviation of %f."

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -22,8 +22,8 @@ from uncertainties import (
 )
 from uncertainties.ops import partial_derivative
 from helpers import (
-    numbers_close,
-    ufloats_close,
+    nan_close,
+    ufloat_nan_close,
 )
 
 
@@ -135,20 +135,20 @@ def test_ufloat_fromstr():
 
         # Without tag:
         num = ufloat_fromstr(representation)
-        assert numbers_close(num.nominal_value, values[0])
-        assert numbers_close(num.std_dev, values[1])
+        assert nan_close(num.nominal_value, values[0])
+        assert nan_close(num.std_dev, values[1])
         assert num.tag is None
 
         # With a tag as positional argument:
         num = ufloat_fromstr(representation, "test variable")
-        assert numbers_close(num.nominal_value, values[0])
-        assert numbers_close(num.std_dev, values[1])
+        assert nan_close(num.nominal_value, values[0])
+        assert nan_close(num.std_dev, values[1])
         assert num.tag == "test variable"
 
         # With a tag as keyword argument:
         num = ufloat_fromstr(representation, tag="test variable")
-        assert numbers_close(num.nominal_value, values[0])
-        assert numbers_close(num.std_dev, values[1])
+        assert nan_close(num.nominal_value, values[0])
+        assert nan_close(num.std_dev, values[1])
         assert num.tag == "test variable"
 
 
@@ -597,35 +597,35 @@ def test_wrapped_func_no_args_no_kwargs():
 
     ## Fully automatic numerical derivatives:
     f_wrapped = uncert_core.wrap(f)
-    assert ufloats_close(f_auto_unc(x, y), f_wrapped(x, y))
+    assert ufloat_nan_close(f_auto_unc(x, y), f_wrapped(x, y))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
+    assert ufloat_nan_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
 
     ## Automatic additional derivatives for non-defined derivatives,
     ## and explicit None derivative:
     f_wrapped = uncert_core.wrap(f, [None])  # No derivative for y
-    assert ufloats_close(f_auto_unc(x, y), f_wrapped(x, y))
+    assert ufloat_nan_close(f_auto_unc(x, y), f_wrapped(x, y))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
+    assert ufloat_nan_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
 
     ### Explicit derivatives:
 
     ## Fully defined derivatives:
     f_wrapped = uncert_core.wrap(f, [lambda x, y: 2, lambda x, y: math.cos(y)])
 
-    assert ufloats_close(f_auto_unc(x, y), f_wrapped(x, y))
+    assert ufloat_nan_close(f_auto_unc(x, y), f_wrapped(x, y))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
+    assert ufloat_nan_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
 
     ## Automatic additional derivatives for non-defined derivatives:
     f_wrapped = uncert_core.wrap(f, [lambda x, y: 2])  # No derivative for y
-    assert ufloats_close(f_auto_unc(x, y), f_wrapped(x, y))
+    assert ufloat_nan_close(f_auto_unc(x, y), f_wrapped(x, y))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
+    assert ufloat_nan_close(f_auto_unc(y=y, x=x), f_wrapped(y=y, x=x))
 
 
 def test_wrapped_func_args_no_kwargs():
@@ -655,12 +655,12 @@ def test_wrapped_func_args_no_kwargs():
 
     ## Fully automatic numerical derivatives:
     f_wrapped = uncert_core.wrap(f)
-    assert ufloats_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
+    assert ufloat_nan_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
 
     ## Automatic additional derivatives for non-defined derivatives,
     ## and explicit None derivative:
     f_wrapped = uncert_core.wrap(f, [None])  # No derivative for y
-    assert ufloats_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
+    assert ufloat_nan_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
 
     ### Explicit derivatives:
 
@@ -675,13 +675,13 @@ def test_wrapped_func_args_no_kwargs():
         ],
     )
 
-    assert ufloats_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
+    assert ufloat_nan_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
 
     ## Automatic additional derivatives for non-defined derivatives:
 
     # No derivative for y:
     f_wrapped = uncert_core.wrap(f, [lambda x, y, *args: 2])
-    assert ufloats_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
+    assert ufloat_nan_close(f_auto_unc(x, y, *args), f_wrapped(x, y, *args))
 
 
 def test_wrapped_func_no_args_kwargs():
@@ -712,10 +712,12 @@ def test_wrapped_func_no_args_kwargs():
 
     ## Fully automatic numerical derivatives:
     f_wrapped = uncert_core.wrap(f)
-    assert ufloats_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
+    assert ufloat_nan_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs))
+    assert ufloat_nan_close(
+        f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs)
+    )
 
     ## Automatic additional derivatives for non-defined derivatives,
     ## and explicit None derivative:
@@ -723,26 +725,32 @@ def test_wrapped_func_no_args_kwargs():
     # No derivative for positional-or-keyword parameter y, no
     # derivative for optional-keyword parameter z:
     f_wrapped = uncert_core.wrap(f, [None])
-    assert ufloats_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
+    assert ufloat_nan_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs))
+    assert ufloat_nan_close(
+        f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs)
+    )
 
     # No derivative for positional-or-keyword parameter y, no
     # derivative for optional-keyword parameter z:
     f_wrapped = uncert_core.wrap(f, [None], {"z": None})
-    assert ufloats_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
+    assert ufloat_nan_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs))
+    assert ufloat_nan_close(
+        f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs)
+    )
 
     # No derivative for positional-or-keyword parameter y, derivative
     # for optional-keyword parameter z:
     f_wrapped = uncert_core.wrap(f, [None], {"z": lambda x, y, **kwargs: 3})
-    assert ufloats_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
+    assert ufloat_nan_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs))
+    assert ufloat_nan_close(
+        f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs)
+    )
 
     ### Explicit derivatives:
 
@@ -753,18 +761,22 @@ def test_wrapped_func_no_args_kwargs():
         {"z:": lambda x, y, **kwargs: 3},
     )
 
-    assert ufloats_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
+    assert ufloat_nan_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs))
+    assert ufloat_nan_close(
+        f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs)
+    )
 
     ## Automatic additional derivatives for non-defined derivatives:
 
     # No derivative for y or z:
     f_wrapped = uncert_core.wrap(f, [lambda x, y, **kwargs: 2])
-    assert ufloats_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
+    assert ufloat_nan_close(f_auto_unc(x, y, **kwargs), f_wrapped(x, y, **kwargs))
 
     # Call with keyword arguments:
-    assert ufloats_close(f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs))
+    assert ufloat_nan_close(
+        f_auto_unc(y=y, x=x, **kwargs), f_wrapped(y=y, x=x, **kwargs)
+    )
 
 
 def test_wrapped_func_args_kwargs():
@@ -798,7 +810,7 @@ def test_wrapped_func_args_kwargs():
     ## Fully automatic numerical derivatives:
     f_wrapped = uncert_core.wrap(f)
 
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_auto_unc(x, y, *args, **kwargs),
         f_wrapped(x, y, *args, **kwargs),
         tolerance=1e-5,
@@ -810,7 +822,7 @@ def test_wrapped_func_args_kwargs():
     # No derivative for positional-or-keyword parameter y, no
     # derivative for optional-keyword parameter z:
     f_wrapped = uncert_core.wrap(f, [None, None, None, lambda x, y, *args, **kwargs: 4])
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_auto_unc(x, y, *args, **kwargs),
         f_wrapped(x, y, *args, **kwargs),
         tolerance=1e-5,
@@ -819,7 +831,7 @@ def test_wrapped_func_args_kwargs():
     # No derivative for positional-or-keyword parameter y, no
     # derivative for optional-keyword parameter z:
     f_wrapped = uncert_core.wrap(f, [None], {"z": None})
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_auto_unc(x, y, *args, **kwargs),
         f_wrapped(x, y, *args, **kwargs),
         tolerance=1e-5,
@@ -828,7 +840,7 @@ def test_wrapped_func_args_kwargs():
     # No derivative for positional-or-keyword parameter y, derivative
     # for optional-keyword parameter z:
     f_wrapped = uncert_core.wrap(f, [None], {"z": lambda x, y, *args, **kwargs: 3})
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_auto_unc(x, y, *args, **kwargs),
         f_wrapped(x, y, *args, **kwargs),
         tolerance=1e-5,
@@ -843,7 +855,7 @@ def test_wrapped_func_args_kwargs():
         {"z:": lambda x, y, *args, **kwargs: 3},
     )
 
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_auto_unc(x, y, *args, **kwargs),
         f_wrapped(x, y, *args, **kwargs),
         tolerance=1e-5,
@@ -853,7 +865,7 @@ def test_wrapped_func_args_kwargs():
 
     # No derivative for y or z:
     f_wrapped = uncert_core.wrap(f, [lambda x, y, *args, **kwargs: 2])
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_auto_unc(x, y, *args, **kwargs),
         f_wrapped(x, y, *args, **kwargs),
         tolerance=1e-5,
@@ -898,9 +910,11 @@ def test_wrapped_func():
 
     # The random variables must be the same (full correlation):
 
-    assert ufloats_close(f_wrapped(angle, *[1, angle]), f_auto_unc(angle, *[1, angle]))
+    assert ufloat_nan_close(
+        f_wrapped(angle, *[1, angle]), f_auto_unc(angle, *[1, angle])
+    )
 
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_wrapped(angle, *[list_value, angle]), f_auto_unc(angle, *[list_value, angle])
     )
 
@@ -917,7 +931,7 @@ def test_wrapped_func():
 
     x = uncert_core.ufloat(10, 1)
 
-    assert numbers_close(
+    assert nan_close(
         f_wrapped(x, "string argument", x, x, x).std_dev, (1 + 2 + 3 + 4) * x.std_dev
     )
 
@@ -953,7 +967,7 @@ def test_wrap_with_kwargs():
     z = ufloat(100, 0.111)
     t = ufloat(0.1, 0.1111)
 
-    assert ufloats_close(
+    assert ufloat_nan_close(
         f_wrapped(x, y, z, t=t), f_auto_unc(x, y, z, t=t), tolerance=1e-5
     )
 
@@ -1060,11 +1074,11 @@ def test_covariances():
     z = -3 * x
     covs = uncert_core.covariance_matrix([x, y, z])
     # Diagonal elements are simple:
-    assert numbers_close(covs[0][0], 0.01)
-    assert numbers_close(covs[1][1], 0.04)
-    assert numbers_close(covs[2][2], 0.09)
+    assert nan_close(covs[0][0], 0.01)
+    assert nan_close(covs[1][1], 0.04)
+    assert nan_close(covs[2][2], 0.09)
     # Non-diagonal elements:
-    assert numbers_close(covs[0][1], -0.02)
+    assert nan_close(covs[0][1], -0.02)
 
 
 ###############################################################################
@@ -1142,9 +1156,9 @@ else:
         covs = uncert_core.covariance_matrix([x, y, z])
 
         # Test of the diagonal covariance elements:
-        assert uarrays_close(
+        assert np.isclose(
             numpy.array([v.std_dev**2 for v in (x, y, z)]), numpy.array(covs).diagonal()
-        )
+        ).all()
 
         # "Inversion" of the covariance matrix: creation of new
         # variables:
@@ -1155,15 +1169,22 @@ else:
         )
 
         # Even the uncertainties should be correctly reconstructed:
-        assert uarrays_close(numpy.array((x, y, z)), numpy.array((x_new, y_new, z_new)))
+        from uncertainties.unumpy.core import nominal_values, std_devs
+
+        orig_uarr = np.array((x, y, z))
+        new_uarr = np.array((x_new, y_new, z_new))
+        assert np.isclose(nominal_values(orig_uarr), nominal_values(new_uarr)).all()
+        assert np.isclose(std_devs(orig_uarr), std_devs(new_uarr)).all()
 
         # ... and the covariances too:
-        assert uarrays_close(
+        assert np.isclose(
             numpy.array(covs),
             numpy.array(uncert_core.covariance_matrix([x_new, y_new, z_new])),
-        )
+        ).all()
 
-        assert uarrays_close(numpy.array([z_new]), numpy.array([-3 * x_new + y_new]))
+        assert uarrays_close(
+            numpy.array([z_new]), numpy.array([-3 * x_new + y_new])
+        ).all()
 
         ####################
 
@@ -1182,17 +1203,17 @@ else:
             [x.nominal_value for x in [u, v, sum_value]], cov_matrix
         )
 
-        # uarrays_close() is used instead of numbers_close() because
-        # it compares uncertainties too:
-        assert uarrays_close(numpy.array([u]), numpy.array([u2]))
-        assert uarrays_close(numpy.array([v]), numpy.array([v2]))
-        assert uarrays_close(numpy.array([sum_value]), numpy.array([sum2]))
-        assert uarrays_close(numpy.array([0]), numpy.array([sum2 - (u2 + 2 * v2)]))
+        assert nan_close(u.n, u2.n)
+        assert nan_close(v.n, v2.n)
+        assert nan_close(sum_value.n, sum2.n)
+        assert nan_close(sum_value.s, sum2.s)
+        assert nan_close(0, (sum2 - (u2 + 2 * v2)).n)
+        assert nan_close(0, (sum2 - (u2 + 2 * v2)).s, abs_tol=1e-6)
 
         # Spot checks of the correlation matrix:
         corr_matrix = uncert_core.correlation_matrix([u, v, sum_value])
-        assert numbers_close(corr_matrix[0, 0], 1)
-        assert numbers_close(corr_matrix[1, 2], 2 * v.std_dev / sum_value.std_dev)
+        assert nan_close(corr_matrix[0, 0], 1)
+        assert nan_close(corr_matrix[1, 2], 2 * v.std_dev / sum_value.std_dev)
 
         ####################
 
@@ -1208,11 +1229,11 @@ else:
         # Since the numbers are very small, we need to compare them
         # in a stricter way, that handles the case of a 0 variance
         # in `variables`:
-        assert numbers_close(
-            1e66 * cov[0, 0], 1e66 * variables[0].s ** 2, tolerance=1e-5
+        assert nan_close(
+            1e66 * cov[0, 0], 1e66 * variables[0].s ** 2, rel_tol=1e-5, abs_tol=1e-5
         )
-        assert numbers_close(
-            1e66 * cov[1, 1], 1e66 * variables[1].s ** 2, tolerance=1e-5
+        assert nan_close(
+            1e66 * cov[1, 1], 1e66 * variables[1].s ** 2, rel_tol=1e-5, abs_tol=1e-5
         )
 
         ####################
@@ -1226,10 +1247,12 @@ else:
         variables = uncert_core.correlated_values(nom_values, cov)
 
         for variable, nom_value, variance in zip(variables, nom_values, cov.diagonal()):
-            assert numbers_close(variable.n, nom_value)
-            assert numbers_close(variable.s**2, variance)
+            assert nan_close(variable.n, nom_value)
+            assert nan_close(variable.s**2, variance)
 
-        assert uarrays_close(cov, numpy.array(uncert_core.covariance_matrix(variables)))
+        assert np.isclose(
+            cov, numpy.array(uncert_core.covariance_matrix(variables))
+        ).all()
 
     def test_correlated_values_correlation_mat():
         """
@@ -1267,18 +1290,21 @@ else:
         # it compares uncertainties too:
 
         # Test of individual variables:
-        assert uarrays_close(numpy.array([x]), numpy.array([x2]))
-        assert uarrays_close(numpy.array([y]), numpy.array([y2]))
-        assert uarrays_close(numpy.array([z]), numpy.array([z2]))
+        assert nan_close(x.n, x2.n)
+        assert nan_close(x.s, x2.s)
+        assert nan_close(y.n, y2.n)
+        assert nan_close(y.s, y2.s)
+        assert nan_close(z.n, z2.n)
+        assert nan_close(z.s, z2.s)
 
-        # Partial correlation test:
-        assert uarrays_close(numpy.array([0]), numpy.array([z2 - (-3 * x2 + y2)]))
+        assert nan_close(0, (z2 - (-3 * x2 + y2)).n)
+        assert nan_close(0, (z2 - (-3 * x2 + y2)).s, abs_tol=1e-6)
 
         # Test of the full covariance matrix:
-        assert uarrays_close(
+        assert np.isclose(
             numpy.array(cov_mat),
             numpy.array(uncert_core.covariance_matrix([x2, y2, z2])),
-        )
+        ).all()
 
 
 @pytest.mark.skipif(

--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -9,7 +9,7 @@ import uncertainties
 import uncertainties.core as uncert_core
 from uncertainties import ufloat, unumpy
 from uncertainties.unumpy import core
-from helpers import numbers_close, uarrays_close
+from helpers import nan_close, uarrays_close
 
 
 def test_numpy():
@@ -100,7 +100,7 @@ def derivatives_close(x, y):
         return False  # Not the same variables
 
     return all(
-        numbers_close(x.derivatives[var], y.derivatives[var]) for var in x.derivatives
+        nan_close(x.derivatives[var], y.derivatives[var]) for var in x.derivatives
     )
 
 
@@ -127,11 +127,11 @@ def test_inverse():
     # Checks of the numerical values: the diagonal elements of the
     # inverse should be the inverses of the diagonal elements of
     # m (because we started with a triangular matrix):
-    assert numbers_close(
+    assert nan_close(
         1 / m_nominal_values[0, 0], m_inv_uncert[0, 0].nominal_value
     ), "Wrong value"
 
-    assert numbers_close(
+    assert nan_close(
         1 / m_nominal_values[1, 1], m_inv_uncert[1, 1].nominal_value
     ), "Wrong value"
 
@@ -147,10 +147,10 @@ def test_inverse():
     m_double_inverse = m_inverse.I
     # The initial matrix should be recovered, including its
     # derivatives, which define covariances:
-    assert numbers_close(m_double_inverse[0, 0].nominal_value, m[0, 0].nominal_value)
-    assert numbers_close(m_double_inverse[0, 0].std_dev, m[0, 0].std_dev)
+    assert nan_close(m_double_inverse[0, 0].nominal_value, m[0, 0].nominal_value)
+    assert nan_close(m_double_inverse[0, 0].std_dev, m[0, 0].std_dev)
 
-    assert uarrays_close(m_double_inverse, m)
+    assert uarrays_close(m_double_inverse, m).all()
 
     # Partial test:
     assert derivatives_close(m_double_inverse[0, 0], m[0, 0])
@@ -167,7 +167,7 @@ def test_inverse():
 
     # Correlations between m and m_inverse should create a perfect
     # inversion:
-    assert uarrays_close(m * m_inverse, numpy.eye(m.shape[0]))
+    assert uarrays_close(m * m_inverse, numpy.eye(m.shape[0])).all()
 
 
 def test_wrap_array_func():
@@ -200,7 +200,7 @@ def test_wrap_array_func():
     m_f_wrapped = f_wrapped(m, 2, factor=10)
     m_f_unc = f_unc(m, 2, factor=10)
 
-    assert uarrays_close(m_f_wrapped, m_f_unc)
+    assert uarrays_close(m_f_wrapped, m_f_unc).all()
 
 
 def test_pseudo_inverse():
@@ -218,7 +218,7 @@ def test_pseudo_inverse():
     rcond = 1e-8  # Test of the second argument to pinv()
     m_pinv_num = pinv_num(m, rcond)
     m_pinv_package = core.pinv(m, rcond)
-    assert uarrays_close(m_pinv_num, m_pinv_package)
+    assert uarrays_close(m_pinv_num, m_pinv_package).all()
 
     ##########
     # Example with a non-full rank rectangular matrix:
@@ -226,14 +226,14 @@ def test_pseudo_inverse():
     m = unumpy.matrix([vector, vector])
     m_pinv_num = pinv_num(m, rcond)
     m_pinv_package = core.pinv(m, rcond)
-    assert uarrays_close(m_pinv_num, m_pinv_package)
+    assert uarrays_close(m_pinv_num, m_pinv_package).all()
 
     ##########
     # Example with a non-full-rank square matrix:
     m = unumpy.matrix([[ufloat(10, 1), 0], [3, 0]])
     m_pinv_num = pinv_num(m, rcond)
     m_pinv_package = core.pinv(m, rcond)
-    assert uarrays_close(m_pinv_num, m_pinv_package)
+    assert uarrays_close(m_pinv_num, m_pinv_package).all()
 
 
 def test_broadcast_funcs():


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Description:

- `uncertainties` still uses some custom "is close" checks. These checks should be delegated to `math.isclose` and `numpy.isclose`.
- The `uarrays_close` function doesn't actually check that the `UFloat`s in the arrays are close. Rather it checks that the nominal values are close and the std_devs are close (doesn't ensure correlation)
- The `uarrays_close` also uses the `to_affine_scalar` function. With discussions like #295 and others we are moving towards more tight type control. Some of the changes going into `4.0.0` drop dependence on `to_affine_scalar` so I would like to remove it entirely. It is not necessary in the `uarrays_close` test function so removing it there is the first step towards removing it later.