### PR TITLE
Fix Sphinx copyright year substitution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Change Log
 Unreleased
 ----------
 
+Fixes:
+
 - Increases the stacklevel of the warning about `std_dev==0` so that it blames
   the caller rather than blaming the `ufloat()` function.
+- Adjusts the Sphinx configuration to allow for reproducible builds using
+  ``SOURCE_DATE_EPOCH``.
 
 3.2.3   2025-April-18
 -----------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "uncertainties"
-copyright = f"2010–{date.today().year}, Eric O. LEBIGOT (EOL)"
+copyright = f"2010-{date.today().year}, Eric O. LEBIGOT (EOL)"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Using a Unicode en dash to separate years in the Sphinx `copyright` option results in unreproducible builds (in the sense of https://reproducible-builds.org/), because Sphinx's special handling of `SOURCE_DATE_EPOCH` only works when the separator is an ASCII hyphen. The Sphinx developers seem to have considered changing this and then decided against it (see
https://github.com/sphinx-doc/sphinx/pull/12738), so it seems best to adjust the configuration here.

- [N/A] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [N/A] The change is fully covered by automated unit tests
- [N/A] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
