### PR TITLE
Add warnings to documentation for deprecated features

### DIFF
--- a/doc/numpy_guide.rst
+++ b/doc/numpy_guide.rst
@@ -83,6 +83,9 @@ through NumPy, thanks to NumPy's support of arrays of arbitrary objects:
 Matrices
 ^^^^^^^^
 
+.. warning::
+   ``unumpy.umatrix`` is deprecated and will be removed in Uncertainties 4.0.
+
 Matrices of numbers with uncertainties are best created in one of
 two ways.  The first way is similar to using :func:`uarray`:
 

--- a/doc/tech_guide.rst
+++ b/doc/tech_guide.rst
@@ -96,6 +96,11 @@ are completely uncorrelated.
 Comparison operators
 --------------------
 
+.. warning::
+   Support for comparing variables with uncertainties is deprecated and will be
+   removed in Uncertainties 4.0. The behavior of ``bool`` will also be changed
+   to always return ``True`` for ``UFloat`` objects.
+
 Comparison operations (>, ==, etc.) on numbers with uncertainties have
 a **pragmatic semantics**, in this package: numbers with uncertainties
 can be used wherever Python numbers are used, most of the time with a

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -171,6 +171,10 @@ The functions in the :mod:`uncertainties.umath` module include:
 Comparison operators
 ====================
 
+.. warning::
+   Support for comparing variables with uncertainties is deprecated and will be
+   removed in Uncertainties 4.0.
+
 Comparison operators (``==``, ``!=``, ``>``, ``<``, ``>=``, and ``<=``) for Variables with
 uncertainties are somewhat complicated, and need special attention.  As we
 hinted at above, and will explore in more detail below and in the


### PR DESCRIPTION
Warnings are added related to umatrix and comparison operators.

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
