### PR TITLE
No negative std dev exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ Removes:
    `float` this means that the equality comparison always returns `False`.
 - [**BREAKING**] The `uncertainties` package is generally dropping formal support for
    edge cases involving `UFloat` objects with `std_dev == 0`.
+- [**BREAKING**] Previously if a negative `std_dev` was used to construct a `UFloat`
+   object a custom `NegativeStdDev` exception was raised. Now a standard `ValueError`
+   exception is raised.
 
 Unreleased
 ----------

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -55,7 +55,7 @@ def test_ufloat_function_construction():
     assert x.std_dev == 0.14
     assert x.tag == "pi"
 
-    with pytest.raises(uncert_core.NegativeStdDev):
+    with pytest.raises(ValueError):
         _ = ufloat(3, -0.1)
 
     with pytest.raises(TypeError):

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -705,12 +705,6 @@ def wrap(f, derivatives_args=None, derivatives_kwargs=None):
 ###############################################################################
 
 
-class NegativeStdDev(Exception):
-    """Raise for a negative standard deviation"""
-
-    pass
-
-
 class Variable(AffineScalarFunc):
     """
     Representation of a float-like scalar Variable with its uncertainty.
@@ -780,7 +774,7 @@ class Variable(AffineScalarFunc):
         # separately for NaN. But this is not guaranteed, even if it
         # should work on most platforms.)
         if std_dev < 0 and isfinite(std_dev):
-            raise NegativeStdDev("The standard deviation cannot be negative")
+            raise ValueError("The standard deviation cannot be negative")
 
         self._std_dev = float(std_dev)
 


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Get rid of the custom `NegativeStdDev` exception. This exception case is covered by `ValueError`. i.e., the caller is passing in an invalid value for the `std_dev` input.