### PR TITLE
Remove zero std dev tests

### DIFF
--- a/doc/formatting.rst
+++ b/doc/formatting.rst
@@ -159,6 +159,14 @@ the common exponent.
 An uncertainty which is *exactly* **zero** is always formatted as an
 integer:
 
+.. doctest::
+   :hide:
+
+   >>> import warnings
+   >>> original_filters = warnings.filters[:]
+   >>> warnings.filterwarnings("ignore", message=".*std_dev==0")
+
+
 >>> print(ufloat(3.1415, 0))
 3.1415+/-0
 >>> print(ufloat(3.1415e10, 0))
@@ -169,6 +177,12 @@ integer:
 3.14+/-0.00
 >>> print('{:.2f}'.format(ufloat(3.14, 0.00)))
 3.14+/-0
+
+
+.. doctest::
+   :hide:
+
+   >>> warnings.filters = original_filters
 
 **All the digits** of a number with uncertainty are given in its
 representation:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from uncertainties import ufloat, ufloat_fromstr, formatting
 from helpers import nan_close
@@ -35,8 +36,14 @@ def test_small_float():
     a = 1e-324
     b = 3e-324
     assert a < b
-    str(ufloat(a, 0.0))
-    str(ufloat(b, 0.0))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="std_dev==0 may give unexpected_results.",
+            category=UserWarning,
+        )
+        str(ufloat(a, 0.0))
+        str(ufloat(b, 0.0))
 
 
 def test_repr():
@@ -48,7 +55,13 @@ def test_repr():
     assert repr(x) == "3.14159265358979+/-0.25"
 
     x = ufloat(3.14159265358979, 0)
-    assert repr(x) == "3.14159265358979+/-0"
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="std_dev==0 may give unexpected_results.",
+            category=UserWarning,
+        )
+        assert repr(x) == "3.14159265358979+/-0"
 
     # Tagging:
     x = ufloat(3, 1, "length")
@@ -460,7 +473,13 @@ formatting_cases = [  # (Nominal value, uncertainty): {format: result,...}
 @pytest.mark.parametrize("val, std_dev, fmt_spec, expected_str", formatting_cases)
 def test_format(val, std_dev, fmt_spec, expected_str):
     """Test the formatting of numbers with uncertainty."""
-    x = ufloat(val, std_dev)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="std_dev==0 may give unexpected_results.",
+            category=UserWarning,
+        )
+        x = ufloat(val, std_dev)
     actual_str = format(x, fmt_spec)
 
     assert actual_str == expected_str

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,5 +1,4 @@
 import pytest
-import warnings
 
 from uncertainties import ufloat, ufloat_fromstr, formatting
 from helpers import nan_close
@@ -27,6 +26,7 @@ def test_PDG_precision():
         assert formatting.PDG_precision(std_dev) == result
 
 
+@pytest.mark.filterwarnings("ignore:.*std_dev==0")
 def test_small_float():
     """
     Make sure that very small floats do not error, even though printing as str
@@ -36,16 +36,11 @@ def test_small_float():
     a = 1e-324
     b = 3e-324
     assert a < b
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=".*std_dev==0 may give unexpected results",
-            category=UserWarning,
-        )
-        str(ufloat(a, 0.0))
-        str(ufloat(b, 0.0))
+    str(ufloat(a, 0.0))
+    str(ufloat(b, 0.0))
 
 
+@pytest.mark.filterwarnings("ignore:.*std_dev==0")
 def test_repr():
     """Test the representation of numbers with uncertainty."""
 
@@ -54,13 +49,7 @@ def test_repr():
     x = ufloat(3.14159265358979, 0.25)
     assert repr(x) == "3.14159265358979+/-0.25"
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=".*std_dev==0 may give unexpected results",
-            category=UserWarning,
-        )
-        x = ufloat(3.14159265358979, 0)
+    x = ufloat(3.14159265358979, 0)
     assert repr(x) == "3.14159265358979+/-0"
 
     # Tagging:
@@ -470,16 +459,11 @@ formatting_cases = [  # (Nominal value, uncertainty): {format: result,...}
 ]
 
 
+@pytest.mark.filterwarnings("ignore:.*std_dev==0")
 @pytest.mark.parametrize("val, std_dev, fmt_spec, expected_str", formatting_cases)
 def test_format(val, std_dev, fmt_spec, expected_str):
     """Test the formatting of numbers with uncertainty."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=".*std_dev==0 may give unexpected results",
-            category=UserWarning,
-        )
-        x = ufloat(val, std_dev)
+    x = ufloat(val, std_dev)
     actual_str = format(x, fmt_spec)
 
     assert actual_str == expected_str

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -39,7 +39,7 @@ def test_small_float():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message=".*std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected results",
             category=UserWarning,
         )
         str(ufloat(a, 0.0))
@@ -57,7 +57,7 @@ def test_repr():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message=".*std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected results",
             category=UserWarning,
         )
         x = ufloat(3.14159265358979, 0)
@@ -476,7 +476,7 @@ def test_format(val, std_dev, fmt_spec, expected_str):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message=".*std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected results",
             category=UserWarning,
         )
         x = ufloat(val, std_dev)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -54,14 +54,14 @@ def test_repr():
     x = ufloat(3.14159265358979, 0.25)
     assert repr(x) == "3.14159265358979+/-0.25"
 
-    x = ufloat(3.14159265358979, 0)
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message="std_dev==0 may give unexpected_results.",
             category=UserWarning,
         )
-        assert repr(x) == "3.14159265358979+/-0"
+        x = ufloat(3.14159265358979, 0)
+    assert repr(x) == "3.14159265358979+/-0"
 
     # Tagging:
     x = ufloat(3, 1, "length")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -39,7 +39,7 @@ def test_small_float():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected_results.",
             category=UserWarning,
         )
         str(ufloat(a, 0.0))
@@ -57,7 +57,7 @@ def test_repr():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected_results.",
             category=UserWarning,
         )
         x = ufloat(3.14159265358979, 0)
@@ -476,7 +476,7 @@ def test_format(val, std_dev, fmt_spec, expected_str):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected_results.",
             category=UserWarning,
         )
         x = ufloat(val, std_dev)

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -44,13 +44,11 @@ two = ufloat(2, 0.2)
 positive = ufloat(0.3, 0.01)
 positive2 = ufloat(0.3, 0.01)
 negative = ufloat(-0.3, 0.01)
-integer = ufloat(-3, 0)
 non_int_larger_than_one = ufloat(3.1, 0.01)
 positive_smaller_than_one = ufloat(0.3, 0.01)
 
 
 power_derivative_cases = (
-    (negative, integer, -370.37037037037044, float("nan")),
     (negative, one, 1.0, float("nan")),
     (negative, zero, 0.0, float("nan")),
     (zero, non_int_larger_than_one, float("nan"), 0.0),
@@ -106,8 +104,6 @@ def test_power_zero_std_dev_result_cases(first_ufloat, second_ufloat, result_flo
 
 power_reference_cases = [
     (ufloat(-1.1, 0.1), -9),
-    (ufloat(-1, 0), 9),
-    (ufloat(-1.1, 0), 9),
 ]
 
 

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -82,27 +82,13 @@ def test_power_derivatives(first_ufloat, second_ufloat, first_der, second_der):
     assert nan_close(second_der_result, second_der)
 
 
-zero = ufloat(0, 0)
-one = ufloat(1, 0)
 p = ufloat(0.3, 0.01)
 
 power_zero_std_dev_result_cases = [
     (0, p, 0),
     (p, 0, 1),
-    (zero, 0, 1),
     (-p, 0, 1),
-    (0.3, zero, 1),
-    (p, zero, 1),
-    (one, -3, 1),
-    (one, -3.1, 1),
-    (one, 0, 1),
-    (one, 3, 1),
-    (one, 3.1, 1),
-    (one, -p, 1),
-    (one, zero, 1),
-    (one, p, 1),
     (1, -p, 1),
-    (1, zero, 1),
     (1, p, 1),
 ]
 

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -119,7 +119,6 @@ def test_power_wrt_ref(first_ufloat, second_float):
 positive = ufloat(0.3, 0.01)
 negative = ufloat(-0.3, 0.01)
 power_exception_cases = [
-    (ufloat(0, 0), negative, ZeroDivisionError),
     (ufloat(0, 0.1), negative, ZeroDivisionError),
     (negative, positive, ValueError),
 ]
@@ -137,7 +136,6 @@ ZeroDivisionError so these test cases are slightly different than those that app
 test_power_exceptions in test_uncertainties.py.
 """
 umath_power_exception_cases = [
-    (ufloat(0, 0), negative, ValueError),
     (ufloat(0, 0.1), negative, ValueError),
     (negative, positive, ValueError),
 ]

--- a/tests/test_umath.py
+++ b/tests/test_umath.py
@@ -237,12 +237,6 @@ def test_math_module():
     else:
         raise Exception("%s exception expected" % exception_class.__name__)
     try:
-        umath_core.log(ufloat(0, 0))
-    except exception_class as err_ufloat:
-        assert err_math_args == err_ufloat.args
-    else:
-        raise Exception("%s exception expected" % exception_class.__name__)
-    try:
         umath_core.log(ufloat(0, 1))
     except exception_class as err_ufloat:
         assert err_math_args == err_ufloat.args

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -186,7 +186,7 @@ def test_calculate_zero_equality():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected_results.",
             category=UserWarning,
         )
     zero = ufloat(0, 0)

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -497,12 +497,12 @@ def test_basic_access_to_data():
 def test_correlations():
     "Correlations between variables"
 
-    a = ufloat(1, 0)
+    a = ufloat(1, 0.2)
     x = ufloat(4, 0.1)
     y = x * 2 + a
     # Correlations cancel "naive" additions of uncertainties:
     assert y.std_dev != 0
-    normally_zero = y - (x * 2 + 1)
+    normally_zero = y - (x * 2 + a)
     assert normally_zero.nominal_value == 0
     assert normally_zero.std_dev == 0
 

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -437,11 +437,9 @@ def test_comparison_ops():
 
 def test_logic():
     "bool defers to object.__bool__ and always returns True."
-    x = ufloat(3, 0)
     z = ufloat(0, 0.1)
     t = ufloat(-1, 2)
 
-    assert bool(x)
     assert bool(z)
     assert bool(t)
 

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -3,7 +3,6 @@ import json
 import math
 from pathlib import Path
 import random  # noqa
-import warnings
 
 import pytest
 
@@ -183,16 +182,11 @@ def test_ufloat_method_derivativs(func_name, ufloat_tuples):
         )
 
 
+@pytest.mark.filterwarnings("ignore:.*std_dev==0")
 def test_calculate_zero_equality():
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=".*std_dev==0 may give unexpected results",
-            category=UserWarning,
-        )
-        zero = ufloat(0, 0)
-        x = ufloat(1, 0.1)
-        x_zero = x - x
+    zero = ufloat(0, 0)
+    x = ufloat(1, 0.1)
+    x_zero = x - x
     assert zero == x_zero
 
 

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -438,12 +438,10 @@ def test_comparison_ops():
 def test_logic():
     "bool defers to object.__bool__ and always returns True."
     x = ufloat(3, 0)
-    y = ufloat(0, 0)
     z = ufloat(0, 0.1)
     t = ufloat(-1, 2)
 
     assert bool(x)
-    assert bool(y)
     assert bool(z)
     assert bool(t)
 

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -186,7 +186,7 @@ def test_calculate_zero_equality():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message=".*std_dev==0 may give unexpected_results.",
+            message=".*std_dev==0 may give unexpected results",
             category=UserWarning,
         )
     zero = ufloat(0, 0)

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -114,6 +114,7 @@ ufloat_from_str_cases = [
 ]
 
 
+@pytest.mark.filterwarnings("ignore:.*std_dev==0")
 @pytest.mark.parametrize("input_str,nominal_value,std_dev", ufloat_from_str_cases)
 def test_ufloat_fromstr(input_str, nominal_value, std_dev):
     num = ufloat_fromstr(input_str)

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -189,9 +189,9 @@ def test_calculate_zero_equality():
             message=".*std_dev==0 may give unexpected results",
             category=UserWarning,
         )
-    zero = ufloat(0, 0)
-    x = ufloat(1, 0.1)
-    x_zero = x - x
+        zero = ufloat(0, 0)
+        x = ufloat(1, 0.1)
+        x_zero = x - x
     assert zero == x_zero
 
 
@@ -335,13 +335,6 @@ def test_pickling():
 
 def test_comparison_ops():
     "Test of comparison operators"
-
-    # Operations on quantities equivalent to Python numbers must still
-    # be correct:
-    b = ufloat(10, 0)
-    c = ufloat(10, 0)
-    assert b == c
-
     x = ufloat(3, 0.1)
 
     assert x == x
@@ -437,16 +430,8 @@ def test_comparison_ops():
 
     # With different numbers:
     test_all_comparison_ops(ufloat(3, 0.1), ufloat(-2, 0.1))
-    test_all_comparison_ops(
-        ufloat(0, 0),  # Special number
-        ufloat(1, 1),
-    )
-    test_all_comparison_ops(
-        ufloat(0, 0),  # Special number
-        ufloat(0, 0.1),
-    )
+
     # With identical numbers:
-    test_all_comparison_ops(ufloat(0, 0), ufloat(0, 0))
     test_all_comparison_ops(ufloat(1, 1), ufloat(1, 1))
 
 

--- a/tests/test_uncertainties.py
+++ b/tests/test_uncertainties.py
@@ -3,6 +3,7 @@ import json
 import math
 from pathlib import Path
 import random  # noqa
+import warnings
 
 import pytest
 
@@ -182,6 +183,12 @@ def test_ufloat_method_derivativs(func_name, ufloat_tuples):
 
 
 def test_calculate_zero_equality():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="std_dev==0 may give unexpected_results.",
+            category=UserWarning,
+        )
     zero = ufloat(0, 0)
     x = ufloat(1, 0.1)
     x_zero = x - x

--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -37,7 +37,7 @@ def test_numpy():
     assert numpy.exp(arr).all()  # All elements > 0
     # Equivalent with an array of AffineScalarFunc objects:
     try:
-        numpy.exp(arr + ufloat(0, 0))
+        numpy.exp(arr + ufloat(0, 0.1))
     except (AttributeError, TypeError):
         # In numpy<1.17, an AttributeError is raised in this situation. This was
         # considered a bug however, and in numpy 1.17 it was changed to a

--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -160,7 +160,7 @@ def test_wrap_array_func():
 
     ##########
     # Full rank rectangular matrix:
-    m = numpy.array([[ufloat(10, 1), -3.1], [0, ufloat(3, 0)], [1, -3.1]])
+    m = numpy.array([[ufloat(10, 1), -3.1], [0, ufloat(3, 0.1)], [1, -3.1]])
 
     # Numerical and package (analytical) pseudo-inverses: they must be
     # the same:
@@ -178,7 +178,7 @@ def test_pseudo_inverse():
 
     ##########
     # Full rank rectangular matrix:
-    m = numpy.array([[ufloat(10, 1), -3.1], [0, ufloat(3, 0)], [1, -3.1]])
+    m = numpy.array([[ufloat(10, 1), -3.1], [0, ufloat(3, 0.1)], [1, -3.1]])
 
     # Numerical and package (analytical) pseudo-inverses: they must be
     # the same:

--- a/tests/test_unumpy.py
+++ b/tests/test_unumpy.py
@@ -74,7 +74,7 @@ def derivatives_close(x, y):
 def test_inverse():
     "Tests of the matrix inverse"
 
-    m = numpy.array([[ufloat(10, 1), -3.1], [0, ufloat(3, 0)]])
+    m = numpy.array([[ufloat(10, 1), -3.1], [0, ufloat(3, 0.1)]])
     m_nominal_values = unumpy.nominal_values(m)
 
     # "Regular" inverse matrix, when uncertainties are not taken


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Right now the tests raise many warnings about `std_dev=0` not being supported. I am eliminating the tests that raise those warnings.