### PR TITLE
deprecate derivatives and error_components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Adds:
 
 Deprecates:
 
+- The `AffineScalarFunc.derivatives` property has been marked as deprecated. This
+   property will be removed in a future release.
+- The `AffineScalarFunc.error_components()` method has been marked as deprecated. This
+   method will be replaced by a property of the same name in a future release.
 - Support for interoperability between `uncertainties` `AffineScalarFunc` scalar objects
    and `np.matrix` objects is now marked as deprecated. According to the
    `numpy documentation <https://numpy.org/doc/stable/reference/generated/numpy.matrix.html>`_

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -445,6 +445,12 @@ class AffineScalarFunc(object):
 
         This mapping is cached, for subsequent calls.
         """
+        warn(
+            f"{self.__class__.___name__}.derivatives() is deprecated. It will be "
+            f"removed in a future release.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
         if not self._linear_part.expanded():
             self._linear_part.expand()
@@ -469,6 +475,14 @@ class AffineScalarFunc(object):
         object take scalar values (and are not a tuple, like what
         math.frexp() returns, for instance).
         """
+        warn(
+            f"{self.__class__.___name__}.error_components() is currently an instance "
+            f"method. In a future release it will be become an instance property and "
+            f"will be accessed by {self.__class__.__name__}.error_components (with no "
+            f"parentheses).",
+            FutureWarning,
+            stacklevel=2,
+        )
 
         # Calculation of the variance:
         error_components = {}

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -446,7 +446,7 @@ class AffineScalarFunc(object):
         This mapping is cached, for subsequent calls.
         """
         warn(
-            f"{self.__class__.___name__}.derivatives() is deprecated. It will "
+            f"{self.__class__.__name__}.derivatives() is deprecated. It will "
             f"be removed in a future release.",
             FutureWarning,
             stacklevel=2,
@@ -476,7 +476,7 @@ class AffineScalarFunc(object):
         math.frexp() returns, for instance).
         """
         warn(
-            f"{self.__class__.___name__}.error_components() is currently an "
+            f"{self.__class__.__name__}.error_components() is currently an "
             f"instance method. This method is deprecated. In a future release it will "
             f"be replaced with an instance property by the same name. It will be "
             f"accessed by {self.__class__.__name__}.error_components (with no "

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -446,8 +446,8 @@ class AffineScalarFunc(object):
         This mapping is cached, for subsequent calls.
         """
         warn(
-            f"{self.__class__.___name__}.derivatives() is deprecated. It will be "
-            f"removed in a future release.",
+            f"{self.__class__.___name__}.derivatives() is deprecated. It will "
+            f"be removed in a future release.",
             FutureWarning,
             stacklevel=2,
         )
@@ -476,9 +476,10 @@ class AffineScalarFunc(object):
         math.frexp() returns, for instance).
         """
         warn(
-            f"{self.__class__.___name__}.error_components() is currently an instance "
-            f"method. In a future release it will be become an instance property and "
-            f"will be accessed by {self.__class__.__name__}.error_components (with no "
+            f"{self.__class__.___name__}.error_components() is currently an "
+            f"instance method. This method is deprecated. In a future release it will "
+            f"be replaced with an instance property by the same name. It will be "
+            f"accessed by {self.__class__.__name__}.error_components (with no "
             f"parentheses).",
             FutureWarning,
             stacklevel=2,


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

. 
- Marks `AffineScalarFunc.derivatives` propert as deprecated
- Marks `AffineScalarFunc.error_components()` as deprecated and that it will be replaced with a property `AffineScalarFunc.error_components`.