### PR TITLE
fix license values in pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Adds:
 - Adjusts the Sphinx configuration to allow for reproducible builds using
   ``SOURCE_DATE_EPOCH``.
 - Mark Python 3.13 and 3.14 as officially supported.
+- Drop support for Python 3.8
 
 Deprecates:
 
@@ -25,6 +26,7 @@ Deprecates:
    and `np.matrix` objects is now marked as deprecated. According to the
    `numpy documentation <https://numpy.org/doc/stable/reference/generated/numpy.matrix.html>`_
    usage of the `np.matrix` class is no longer recommended.
+
 
 3.2.3   2025-April-18
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ keywords = [
     "standard deviation", "derivatives", "partial derivatives",
     "differentiation"
 ]
-license = {text = "Revised BSD License"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Other Audience",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
fixes license settings in `pyproject.toml` to comply with the latest PyPA recommendations/requirements.

- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
