### PR TITLE
3.2.5a

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Change Log
 ===================
 
+
+3.2.5 2026-January-21
+-----------------------
+
+- change warnings about deprecation of error_components() and
+  derivates to PendingDeprecationWarning
+- Drop support for Python 3.8
+
+
 3.2.4   2026-January-9
 -----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "calculations with values with uncertainties, error propagation"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "error propagation", "uncertainties", "uncertainty calculations",
     "standard deviation", "derivatives", "partial derivatives",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 write_to = "uncertainties/version.py"
 version_scheme = "post-release"
 
-
 [project]
 name = "uncertainties"
 dynamic = ["version"]
@@ -21,18 +20,17 @@ keywords = [
     "standard deviation", "derivatives", "partial derivatives",
     "differentiation"
 ]
-license = {text = "Revised BSD License"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Other Audience",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -448,7 +448,7 @@ class AffineScalarFunc(object):
         warn(
             f"{self.__class__.__name__}.derivatives() is deprecated. It will "
             f"be removed in a future release.",
-            FutureWarning,
+            PendingDeprecationWarning,
             stacklevel=2,
         )
 
@@ -481,7 +481,7 @@ class AffineScalarFunc(object):
             f"be replaced with an instance property by the same name. It will be "
             f"accessed by {self.__class__.__name__}.error_components (with no "
             f"parentheses).",
-            FutureWarning,
+            PendingDeprecationWarning,
             stacklevel=2,
         )
 


### PR DESCRIPTION
- [x] Closes #352. #350
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This should be merged and tagged as 3.2.5