### PR TITLE
`ufloat_fromstr` can now also parse uncertainties as percentages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Adds:
 - Adjusts the Sphinx configuration to allow for reproducible builds using
   ``SOURCE_DATE_EPOCH``.
 - Mark Python 3.13 and 3.14 as officially supported.
+- Support for percentage uncertainties in the `ufloat_fromstr` function.
 
 Deprecates:
 

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -63,6 +63,8 @@ value:
 >>> x = ufloat_fromstr("0.20(1)")  # Short-hand notation
 >>> x = ufloat_fromstr("20(1)e-2")  # Exponent notation
 >>> x = ufloat_fromstr(u"0.20±0.01")  # Pretty-print form
+>>> x = ufloat_fromstr("0.20±5%")  # Percentage uncertainty
+>>> x = ufloat_fromstr("0.20 (+-5%)")
 >>> x = ufloat_fromstr("0.20")  # Automatic uncertainty of +/-1 on last digit
 
 More details on the :func:`ufloat` and :func:`ufloat_from_str` can be found in

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -603,4 +603,3 @@ def test_percentage_uncertainty_roundtrip():
     x_back = ufloat_fromstr(formatted)
     assert nan_close(x.nominal_value, x_back.nominal_value)
     assert nan_close(x.std_dev, x_back.std_dev, rel_tol=1e-4)
-

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -525,3 +525,82 @@ def test_custom_pretty_print_and_latex():
     # We restore the defaults:
     for var, setting in PREV_CUSTOMIZATIONS.items():
         setattr(formatting, var, setting)
+
+
+def test_percentage_uncertainty_parsing():
+    """
+    Test parsing of strings with percentage uncertainties,
+    e.g., "23 ± 13%", "2.037e5 (±3.270%)", "23 +- 1.3e-5%".
+    The percentage is converted to an absolute uncertainty:
+        uncertainty = value * (percentage / 100)
+    """
+    # Basic cases with different symbols and spacing
+    x = ufloat_fromstr("23 ± 13%")
+    assert nan_close(x.nominal_value, 23.0)
+    assert nan_close(x.std_dev, 2.99)  # 23 * 0.13
+
+    x = ufloat_fromstr("23 +- 13%")
+    assert nan_close(x.nominal_value, 23.0)
+    assert nan_close(x.std_dev, 2.99)
+
+    x = ufloat_fromstr("23(±13%)")
+    assert nan_close(x.nominal_value, 23.0)
+    assert nan_close(x.std_dev, 2.99)
+
+    x = ufloat_fromstr("23 (±13%)")
+    assert nan_close(x.nominal_value, 23.0)
+    assert nan_close(x.std_dev, 2.99)
+
+    x = ufloat_fromstr("23±13%")
+    assert nan_close(x.nominal_value, 23.0)
+    assert nan_close(x.std_dev, 2.99)
+
+    # Scientific notation in value and uncertainty
+    x = ufloat_fromstr("2.037e5 (±3.270%)")
+    assert nan_close(x.nominal_value, 2.037e5)
+    assert nan_close(x.std_dev, 2.037e5 * 0.0327)
+
+    x = ufloat_fromstr("2.037e5 (±3.270e-2%)")
+    assert nan_close(x.nominal_value, 2.037e5)
+    assert nan_close(x.std_dev, 2.037e5 * 0.000327)
+
+    # Negative values
+    x = ufloat_fromstr("-23 ± 13%")
+    assert nan_close(x.nominal_value, -23.0)
+    assert nan_close(x.std_dev, 2.99)  # Uncertainty is always positive
+
+    # Small values
+    x = ufloat_fromstr("0.42 ± 0.5%")
+    assert nan_close(x.nominal_value, 0.42)
+    assert nan_close(x.std_dev, 0.0021)  # 0.42 * 0.005
+
+    # With global exponent
+    x = ufloat_fromstr("(2.037e5 ± 3.270%)e10")
+    assert nan_close(x.nominal_value, 2.037e15)
+    assert nan_close(x.std_dev, 2.037e15 * 0.0327)
+
+    # Edge cases
+    x = ufloat_fromstr("23 ± 0%")
+    assert nan_close(x.nominal_value, 23.0)
+    assert nan_close(x.std_dev, 0.0)
+
+    x = ufloat_fromstr("100 ± 0.001%")
+    assert nan_close(x.nominal_value, 100.0)
+    assert nan_close(x.std_dev, 0.001)  # 100 * 0.00001
+
+
+def test_percentage_uncertainty_roundtrip():
+    """Test that parsing percentage uncertainties produces consistent ufloat objects."""
+    x = ufloat_fromstr("23 ± 13%")
+    formatted = format(x, ".3uf")  # Use 3 significant digits to preserve 2.99
+    x_back = ufloat_fromstr(formatted)
+    assert nan_close(x.nominal_value, x_back.nominal_value)
+    assert nan_close(x.std_dev, x_back.std_dev, rel_tol=1e-4)
+
+    # Test with scientific notation
+    x = ufloat_fromstr("2.037e5 (±3.270%)")
+    formatted = format(x, ".4ue")
+    x_back = ufloat_fromstr(formatted)
+    assert nan_close(x.nominal_value, x_back.nominal_value)
+    assert nan_close(x.std_dev, x_back.std_dev, rel_tol=1e-4)
+

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -989,6 +989,7 @@ def ufloat_fromstr(representation, tag=None):
     >>> x = ufloat_fromstr("12.58 ± 0.23")  # = ufloat(12.58, 0.23)
     >>> x = ufloat_fromstr("3.85e5 +/- 2.3e4")  # = ufloat(3.8e5, 2.3e4)
     >>> x = ufloat_fromstr("(38.5 +/- 2.3)e4")  # = ufloat(3.8e5, 2.3e4)
+    >>> x = ufloat_fromstr("38.5 +- 10%") # = ufloat(38.5, 3.85) (percentage uncertainty)
 
     >>> x = ufloat_fromstr("72.1(2.2)")  # = ufloat(72.1, 2.2)
     >>> x = ufloat_fromstr("72.15(4)")  # = ufloat(72.15, 0.04)

--- a/uncertainties/parsing.py
+++ b/uncertainties/parsing.py
@@ -68,6 +68,7 @@ PERCENTAGE_WITH_UNCERT_RE_MATCH = re.compile(
     re.VERBOSE,
 ).match
 
+
 class NotParenUncert(ValueError):
     """
     Raised when a string representing an exact number or a number with

--- a/uncertainties/parsing.py
+++ b/uncertainties/parsing.py
@@ -48,6 +48,25 @@ NUMBER_WITH_UNCERT_GLOBAL_EXP_RE_MATCH = re.compile(
     re.VERBOSE,
 ).match
 
+# Regexp for percentage uncertainties (e.g., "23 ± 13%", "2.037e5 (±3.270%)")
+PERCENTAGE_WITH_UNCERT_RE_STR = r"""
+    ([+-])?                     # Sign for value
+    ([\d\.]+(?:[eE][+-]?\d+)?)  # Main value (with scientific notation)
+    \s*                         # Optional whitespace
+    \(?                         # Optional opening parenthesis
+    \s*                         # Optional whitespace
+    (?:[±+-]+)?                 # Optional symbol (±, +, -, +-, -+, +/-)
+    \s*                         # Optional whitespace
+    ([\d\.]+(?:[eE][+-]?\d+)?)  # Percentage uncertainty (with scientific notation)
+    \s*                         # Optional whitespace
+    %                           # Literal % symbol
+    \)?                         # Optional closing parenthesis
+"""
+
+PERCENTAGE_WITH_UNCERT_RE_MATCH = re.compile(
+    PERCENTAGE_WITH_UNCERT_RE_STR,
+    re.VERBOSE,
+).match
 
 class NotParenUncert(ValueError):
     """
@@ -121,6 +140,35 @@ def parse_error_in_parentheses(representation):
     uncert_value *= factor
 
     return (value, uncert_value)
+
+
+def parse_percentage_uncertainty(representation):
+    """
+    Parse a string with percentage uncertainty, e.g., "23 ± 13%",
+    "2.037e5 (±3.270%)", or "23 +- 1.3e-5%".
+
+    The percentage uncertainty is converted to an absolute uncertainty:
+        uncertainty = value * (percentage / 100)
+
+    Returns (value, uncertainty) as floats.
+
+    Raises ValueError if the string cannot be parsed.
+    """
+    match = PERCENTAGE_WITH_UNCERT_RE_MATCH(representation)
+    if not match:
+        raise ValueError(cannot_parse_ufloat_msg_pat % representation)
+
+    sign, value_str, uncertainty_str = match.groups()
+
+    try:
+        value = float((sign or "") + value_str)
+        uncertainty_percent = float(uncertainty_str)
+    except ValueError:
+        raise ValueError(cannot_parse_ufloat_msg_pat % representation)
+
+    # Convert percentage uncertainty to absolute
+    uncertainty = abs(value) * (uncertainty_percent / 100)
+    return (value, uncertainty)
 
 
 # Regexp for catching the two variable parts of -1.2×10⁻¹²:
@@ -211,6 +259,13 @@ def str_to_number_with_uncert(representation):
         representation = match.group("simple_num_with_uncert")
     else:
         factor = 1  # No global exponential factor
+
+    try:
+        # Check for percentage uncertainty format
+        parsed_value = parse_percentage_uncertainty(representation)
+        return (parsed_value[0] * factor, parsed_value[1] * factor)
+    except ValueError:
+        pass
 
     match = re.match("(.*)(?:\\+/-|±)(.*)", representation)
     if match:


### PR DESCRIPTION
- [x] Closes #357
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
